### PR TITLE
switching CommentIgnoringArgumentParser from str.split to shlex.split

### DIFF
--- a/src/aws_encryption_sdk_cli/internal/arg_parsing.py
+++ b/src/aws_encryption_sdk_cli/internal/arg_parsing.py
@@ -15,6 +15,7 @@ import argparse
 from collections import defaultdict, OrderedDict
 import copy
 import logging
+import shlex
 from typing import Any, Dict, List, Optional, Sequence, Union  # noqa pylint: disable=unused-import
 
 import aws_encryption_sdk
@@ -39,11 +40,11 @@ class CommentIgnoringArgumentParser(argparse.ArgumentParser):
         drops both full-line and in-line comments.
         """
         converted_line = []
-        for arg in arg_line.split():
+        for arg in shlex.split(str(arg_line)):
             arg = arg.strip()
             if arg.startswith('#'):
                 break
-            converted_line.append(str(arg))
+            converted_line.append(arg)
         return converted_line
 
 

--- a/test/unit/test_arg_parsing.py
+++ b/test/unit/test_arg_parsing.py
@@ -151,6 +151,11 @@ def build_expected_good_args():  # pylint: disable=too-many-locals
         'encryption_context',
         {'some': 'data', 'not': 'secret'}
     ))
+    good_args.append((
+        default_encrypt + ' -c "key with a space=value with a space"',
+        'encryption_context',
+        {'key with a space': 'value with a space'}
+    ))
 
     # algorithm
     algorithm_name = 'AES_128_GCM_IV12_TAG16'


### PR DESCRIPTION
switching CommentIgnoringArgumentParser from str.split to shlex.split to address https://github.com/awslabs/aws-encryption-sdk-cli/issues/35