### PR TITLE
consolidating IO chain functions into IOHandler to simplify configuration

### DIFF
--- a/src/aws_encryption_sdk_cli/internal/metadata.py
+++ b/src/aws_encryption_sdk_cli/internal/metadata.py
@@ -25,6 +25,8 @@ from aws_encryption_sdk.structures import MessageHeader  # noqa pylint: disable=
 from aws_encryption_sdk.internal.structures import MessageHeaderAuthentication  # noqa pylint: disable=unused-import
 import six
 
+__all__ = ('MetadataWriter', 'unicode_b64_encode', 'json_ready_header', 'json_ready_header_auth')
+
 
 @attr.s(hash=False, init=False, cmp=True)
 class MetadataWriter(object):


### PR DESCRIPTION
While not functionally necessary for any of the features we're building, this change significantly simplifies existing interfaces and future changes.

Relevant issue: #76 

This is deceptively simple: most of the changes in the `io_handling` module are simply moving functions into a class.