### PR TITLE
making default master key provider value namespace-specific

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -426,6 +426,7 @@ Execution
 =========
 
 .. code-block:: sh
+
    usage: aws-crypto [-h] [--version] [-e] [-d] [-S]
                      [--write-metadata METADATA_OUTPUT]
                      [--append-metadata METADATA_OUTPUT]
@@ -447,9 +448,9 @@ Execution
                      [--frame-length FRAME_LENGTH] [--max-length MAX_LENGTH]
                      [--suffix [SUFFIX]] [--interactive] [--no-overwrite] [-r]
                      [-v] [-q]
-   
+
    Encrypt or decrypt data using the AWS Encryption SDK
-   
+
    optional arguments:
      -h, --help            show this help message and exit
      --version             show program's version number and exit

--- a/src/aws_encryption_sdk_cli/internal/arg_parsing.py
+++ b/src/aws_encryption_sdk_cli/internal/arg_parsing.py
@@ -21,7 +21,7 @@ from typing import Any, Dict, List, Optional, Sequence, Tuple, Union  # noqa pyl
 import aws_encryption_sdk
 
 from aws_encryption_sdk_cli.exceptions import ParameterParseError
-from aws_encryption_sdk_cli.internal.identifiers import __version__, ALGORITHM_NAMES
+from aws_encryption_sdk_cli.internal.identifiers import __version__, ALGORITHM_NAMES, DEFAULT_MASTER_KEY_PROVIDER
 from aws_encryption_sdk_cli.internal.logging_utils import LOGGER_NAME
 from aws_encryption_sdk_cli.internal.metadata import MetadataWriter
 from aws_encryption_sdk_cli.internal.mypy_types import (  # noqa pylint: disable=unused-import
@@ -472,7 +472,7 @@ def _process_master_key_provider_configs(raw_keys, action):
             _LOGGER.debug(
                 'No master key provider config provided on decrypt request. Using aws-kms with no master keys.'
             )
-            return [{'provider': 'aws-kms', 'key': []}]
+            return [{'provider': DEFAULT_MASTER_KEY_PROVIDER, 'key': []}]
         raise ParameterParseError('No master key provider configuration found.')
 
     processed_configs = []  # type: List[MASTER_KEY_PROVIDER_CONFIG]
@@ -480,7 +480,7 @@ def _process_master_key_provider_configs(raw_keys, action):
         parsed_args = {}  # type: Dict[str, Union[str, List[str]]]
         parsed_args.update(_parse_kwargs(raw_config))
 
-        provider = parsed_args.get('provider', ['aws-kms'])  # If no provider is defined, use aws-kms
+        provider = parsed_args.get('provider', [DEFAULT_MASTER_KEY_PROVIDER])  # If no provider is defined, use aws-kms
         if len(provider) != 1:
             raise ParameterParseError(
                 'Exactly one "provider" must be provided for each master key provider configuration. '
@@ -489,7 +489,7 @@ def _process_master_key_provider_configs(raw_keys, action):
         parsed_args['provider'] = provider[0]
 
         if 'key' not in parsed_args:
-            if action == 'decrypt' and parsed_args['provider'] == 'aws-kms':
+            if action == 'decrypt' and parsed_args['provider'] in ('aws-kms', DEFAULT_MASTER_KEY_PROVIDER):
                 # Special case: aws-kms does not require master key configuration for decrypt.
                 parsed_args['key'] = []
             else:

--- a/src/aws_encryption_sdk_cli/internal/identifiers.py
+++ b/src/aws_encryption_sdk_cli/internal/identifiers.py
@@ -30,6 +30,7 @@ ALGORITHM_NAMES = set([
 MASTER_KEY_PROVIDERS_ENTRY_POINT = 'aws_encryption_sdk_cli.master_key_providers'
 PLUGIN_NAMESPACE_DIVIDER = '::'
 USER_AGENT_SUFFIX = 'AwsEncryptionSdkCli/{}'.format(__version__)
+DEFAULT_MASTER_KEY_PROVIDER = 'aws-encryption-sdk-cli' + PLUGIN_NAMESPACE_DIVIDER + 'aws-kms'
 
 
 class OperationResult(Enum):

--- a/test/unit/test_arg_parsing.py
+++ b/test/unit/test_arg_parsing.py
@@ -20,7 +20,7 @@ from pytest_mock import mocker  # noqa pylint: disable=unused-import
 
 import aws_encryption_sdk_cli
 from aws_encryption_sdk_cli.exceptions import ParameterParseError
-from aws_encryption_sdk_cli.internal import arg_parsing, metadata
+from aws_encryption_sdk_cli.internal import arg_parsing, identifiers, metadata
 
 
 @pytest.yield_fixture
@@ -395,9 +395,18 @@ ALL_CONFIG = (
     [i[-1][0] for i in KEY_PROVIDER_CONFIGS]
 )
 KEY_PROVIDER_CONFIGS.append(ALL_CONFIG)
-KEY_PROVIDER_CONFIGS.append((None, 'decrypt', [{'provider': 'aws-kms', 'key': []}]))
+KEY_PROVIDER_CONFIGS.append((None, 'decrypt', [{'provider': identifiers.DEFAULT_MASTER_KEY_PROVIDER, 'key': []}]))
 KEY_PROVIDER_CONFIGS.append(([['provider=aws-kms']], 'decrypt', [{'provider': 'aws-kms', 'key': []}]))
-KEY_PROVIDER_CONFIGS.append(([['key=ex_key_1']], 'encrypt', [{'provider': 'aws-kms', 'key': ['ex_key_1']}]))
+KEY_PROVIDER_CONFIGS.append((
+    [['provider=' + identifiers.DEFAULT_MASTER_KEY_PROVIDER]],
+    'decrypt',
+    [{'provider': identifiers.DEFAULT_MASTER_KEY_PROVIDER, 'key': []}]
+))
+KEY_PROVIDER_CONFIGS.append((
+    [['key=ex_key_1']],
+    'encrypt',
+    [{'provider': identifiers.DEFAULT_MASTER_KEY_PROVIDER, 'key': ['ex_key_1']}]
+))
 
 
 @pytest.mark.parametrize('source, action, expected', KEY_PROVIDER_CONFIGS)


### PR DESCRIPTION
changing default MKP name from "aws-kms" to include the full namespace "aws-encryption-sdk-cli::aws-kms" https://github.com/awslabs/aws-encryption-sdk-cli/issues/81