### PR TITLE
adding check/failure for parsing key=value pairs when key or value are empty

### DIFF
--- a/src/aws_encryption_sdk_cli/internal/arg_parsing.py
+++ b/src/aws_encryption_sdk_cli/internal/arg_parsing.py
@@ -356,15 +356,18 @@ def _parse_kwargs(args):
     :rtype: dict
     :raises ParameterParseError: if a badly formed parameter if found
     """
+    value_error_message = 'Argument parameter must follow the format "key=value"'
     kwargs = defaultdict(list)  # type: Dict[str, List[str]]
     for arg in args:
         _LOGGER.debug('Attempting to parse argument: %s', arg)
         try:
             key, value = arg.split('=', 1)
+            if not (key and value):
+                raise ParameterParseError(value_error_message)
             kwargs[key].append(value)
         except ValueError:
             _LOGGER.debug('Failed to parse argument')
-            raise ParameterParseError('Argument parameter must follow the format "key=value"')
+            raise ParameterParseError(value_error_message)
     return dict(kwargs)
 
 

--- a/test/unit/test_arg_parsing.py
+++ b/test/unit/test_arg_parsing.py
@@ -360,9 +360,14 @@ def test_parse_kwargs_good(source, expected):
     assert test == expected
 
 
-def test_parse_kwargs_fail():
+@pytest.mark.parametrize('bad_arg', (
+    'key_without_value',
+    'key_with_empty_value=',
+    '=value_with_empty_key'
+))
+def test_parse_kwargs_fail(bad_arg):
     with pytest.raises(ParameterParseError) as excinfo:
-        arg_parsing._parse_kwargs(['asdfsadf'])
+        arg_parsing._parse_kwargs([bad_arg])
 
     excinfo.match(r'Argument parameter must follow the format "key=value"')
 


### PR DESCRIPTION
adding check/failure for parsing key=value pairs when key or value are empty #94 