### PR TITLE
Check for typing only in Python < 3.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 base64io>=1.0.1
 aws-encryption-sdk>=1.3.2
+typing >= 3.6.2;python_version<"3.5"
 setuptools
 attrs>=17.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 base64io>=1.0.1
 aws-encryption-sdk>=1.3.2
-typing>=3.6.2
 setuptools
 attrs>=17.1.0

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def get_version():
 
 def get_requirements():
     """Reads the requirements file."""
-    requirements = read('requirements.txt')
+    requirements = read("requirements.txt")
     return [r for r in requirements.strip().splitlines()]
 
 

--- a/setup.py
+++ b/setup.py
@@ -23,9 +23,7 @@ def get_version():
 
 def get_requirements():
     """Reads the requirements file."""
-    requirements = read("requirements.txt")
-    if sys.version_info < (3, 5):
-        requirements.append('typing >= 3.6.2')
+    requirements = read('requirements.txt')
     return [r for r in requirements.strip().splitlines()]
 
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def get_version():
 def get_requirements():
     """Reads the requirements file."""
     requirements = read("requirements.txt")
-    return [r for r in requirements.strip().splitlines()]
+    return list(requirements.strip().splitlines())
 
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 import io
 import os
 import re
+import sys
 
 from setuptools import find_packages, setup
 
@@ -23,6 +24,8 @@ def get_version():
 def get_requirements():
     """Reads the requirements file."""
     requirements = read("requirements.txt")
+    if sys.version_info < (3, 5):
+        requirements.append('typing >= 3.6.2')
     return [r for r in requirements.strip().splitlines()]
 
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@
 import io
 import os
 import re
-import sys
 
 from setuptools import find_packages, setup
 

--- a/test/unit/internal/test_arg_parsing.py
+++ b/test/unit/internal/test_arg_parsing.py
@@ -93,7 +93,7 @@ def test_comment_ignoring_argument_parser_convert_arg_line_to_args(monkeypatch, 
     monkeypatch.setenv("MY_SPECIAL_VAR", "aVerySpecialPrefix")
     monkeypatch.setenv("ANOTHER_VAR", "someOtherData")
     parser = arg_parsing.CommentIgnoringArgumentParser()
-    parsed_line = [arg for arg in parser.convert_arg_line_to_args(arg_line)]
+    parsed_line = list(parser.convert_arg_line_to_args(arg_line))
     assert line_args == parsed_line
 
 
@@ -114,7 +114,7 @@ def test_comment_ignoring_argument_parser_convert_filename(patch_platform_win32_
     else:
         assert not parser._CommentIgnoringArgumentParser__is_windows
 
-    parsed_line = [arg for arg in parser.convert_arg_line_to_args(expected_transform[0])]
+    parsed_line = list(parser.convert_arg_line_to_args(expected_transform[0]))
     assert expected_transform[1] == parsed_line
 
 
@@ -175,7 +175,7 @@ def test_f_comment_ignoring_argument_parser_convert_filename():
         assert not parser._CommentIgnoringArgumentParser__is_windows
         expected_transform = POSIX_FILEPATH
 
-    parsed_line = [arg for arg in parser.convert_arg_line_to_args(expected_transform[0])]
+    parsed_line = list(parser.convert_arg_line_to_args(expected_transform[0]))
     assert expected_transform[1] == parsed_line
 
 


### PR DESCRIPTION
*No public issue*

*Description of changes:*

Update to only check for Python's typing module if and only if we're running Python before 3.5.0

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
