### PR TITLE
MV bump from 1.1.5 to 1.1.6; update Changelog

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,9 +7,9 @@ Changelog
 
 Operational
 -----------
-* Update requirements to only require the typing module for 
+* Update requirements to only require the typing module for
   Python versions earlier than 3.5
-  
+
 
 1.1.5 -- 2018-08-01
 ===================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,15 @@
 Changelog
 *********
 
+1.1.6 -- 2019-09-30
+===================
+
+Operational
+-----------
+* Update requirements to only require the typing module for 
+  Python versions earlier than 3.5
+  
+
 1.1.5 -- 2018-08-01
 ===================
 

--- a/src/aws_encryption_sdk_cli/internal/identifiers.py
+++ b/src/aws_encryption_sdk_cli/internal/identifiers.py
@@ -31,7 +31,7 @@ __all__ = (
     "DEFAULT_MASTER_KEY_PROVIDER",
     "OperationResult",
 )
-__version__ = "1.1.5"  # type: str
+__version__ = "1.1.6"  # type: str
 
 #: Suffix added to output files if specific output filename is not specified.
 OUTPUT_SUFFIX = {"encrypt": ".encrypted", "decrypt": ".decrypted"}  # type: Dict[str, str]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Moving version from 1.1.5 to 1.1.6 -- Update requirements to only require the typing module for Python versions earlier than 3.5

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
