### PR TITLE
remove install dependency on typing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 base64io>=1.0.1
 aws-encryption-sdk>=1.3.2
-typing >= 3.6.2;python_version<"3.5"
 setuptools
 attrs>=17.1.0

--- a/src/aws_encryption_sdk_cli/internal/arg_parsing.py
+++ b/src/aws_encryption_sdk_cli/internal/arg_parsing.py
@@ -38,8 +38,8 @@ try:  # Python 3.5.0 and 3.5.1 have incompatible typing modules
         RAW_CONFIG,
     )
 except ImportError:  # pragma: no cover
-    # We only actually need these imports when running the mypy checks
-    pass
+    cast = lambda typ, val: val  # noqa pylint: disable=invalid-name
+    # We only actually need the other imports when running the mypy checks
 
 __all__ = ("parse_args",)
 _LOGGER = logging.getLogger(LOGGER_NAME)

--- a/src/aws_encryption_sdk_cli/internal/io_handling.py
+++ b/src/aws_encryption_sdk_cli/internal/io_handling.py
@@ -31,8 +31,9 @@ try:  # Python 3.5.0 and 3.5.1 have incompatible typing modules
     from typing import cast, Dict, IO, List, Type, Union  # noqa pylint: disable=unused-import
     from aws_encryption_sdk_cli.internal.mypy_types import SOURCE, STREAM_KWARGS  # noqa pylint: disable=unused-import
 except ImportError:  # pragma: no cover
-    # We only actually need these imports when running the mypy checks
-    pass
+    cast = lambda typ, val: val  # noqa pylint: disable=invalid-name
+    IO = None  # type: ignore
+    # We only actually need the other imports when running the mypy checks
 
 __all__ = ("IOHandler", "output_filename")
 _LOGGER = logging.getLogger(LOGGER_NAME)

--- a/src/aws_encryption_sdk_cli/internal/logging_utils.py
+++ b/src/aws_encryption_sdk_cli/internal/logging_utils.py
@@ -19,8 +19,8 @@ import logging
 try:  # Python 3.5.0 and 3.5.1 have incompatible typing modules
     from typing import cast, Dict, Sequence, Text, Union  # noqa pylint: disable=unused-import
 except ImportError:  # pragma: no cover
-    # We only actually need these imports when running the mypy checks
-    pass
+    cast = lambda typ, val: val  # noqa pylint: disable=invalid-name
+    # We only actually need the other imports when running the mypy checks
 
 __all__ = ("setup_logger", "LOGGER_NAME")
 LOGGING_LEVELS = {0: logging.CRITICAL, 1: logging.INFO, 2: logging.DEBUG}  # type: Dict[int, int]


### PR DESCRIPTION
This removes our install dependency on typing and adds shims on failed imports where necessary.

*Issue #, if available:*
fixes #166 

*Description of changes:*

I was unable to duplicate the reported issue that triggered #166, but after considering how we are actually using `typing` (ie: only for typehints), I think that the right answer is to remove our install dependency entirely.

We only need `typing` to actually exist and work correctly when we do our type analysis, and we always run that with a version newer than 3.5.2, and the shims let the code work as intended when `typing` is not present.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
