### PR TITLE
chore: set coverage version to support mypy coverage file workaround

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -63,7 +63,7 @@ commands =
 [testenv:mypy-common]
 basepython = python3
 deps =
-    coverage
+    coverage~=4.0
     mypy<=0.560
     mypy_extensions
     typing>=3.6.2


### PR DESCRIPTION
*Description of changes:*

Resolves compatibility issue between coverage 5 and the mypy coverage report.

This unblocks our Travis CI checks.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
