### PR TITLE
fix: Update attrs requirement to >= 20.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 base64io>=1.0.1
 aws-encryption-sdk>=2.0.0
 setuptools
-attrs>=17.1.0
+attrs>=20.1.0


### PR DESCRIPTION
Old versions of attrs break on `order=True`

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
