### PR TITLE
Use ~= in requirements.txt to avoid future breaking changes in ESDK (1.7.x)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 base64io>=1.0.1
-aws-encryption-sdk>=1.7.0
+aws-encryption-sdk~=2.0
 setuptools
 attrs>=17.1.0


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
