### PR TITLE
Fixes for enabling or disabling discovery mode in the CLI (1.x)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,18 @@
 Changelog
 *********
 
+1.8.0 -- 2020-10-27
+===================
+
+Bugfixes
+--------
+* Fix for enabling or disabling discovery mode in the CLI
+
+Breaking Changes
+----------------
+* The ``--discovery`` parameter is removed. It is replaced by a ``discovery`` attribute of the
+  ``--wrapping-keys`` parameter.
+
 1.7.0 -- 2020-09-24
 ===================
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 base64io>=1.0.1
-aws-encryption-sdk>=1.7.0
+aws-encryption-sdk~=1.7
 setuptools
 attrs>=17.1.0

--- a/src/aws_encryption_sdk_cli/__init__.py
+++ b/src/aws_encryption_sdk_cli/__init__.py
@@ -265,7 +265,6 @@ def cli(raw_args=None):
         _LOGGER.debug("Encryption source: %s", args.input)
         _LOGGER.debug("Encryption destination: %s", args.output)
         _LOGGER.debug("Master key provider configuration: %s", args.master_keys)
-        _LOGGER.debug("Discovery mode: %r", args.discovery)
         _LOGGER.debug("Suffix requested: %s", args.suffix)
 
         if args.wrapping_keys is not None:

--- a/src/aws_encryption_sdk_cli/internal/identifiers.py
+++ b/src/aws_encryption_sdk_cli/internal/identifiers.py
@@ -31,7 +31,7 @@ __all__ = (
     "DEFAULT_MASTER_KEY_PROVIDER",
     "OperationResult",
 )
-__version__ = "1.7.0"  # type: str
+__version__ = "1.8.0"  # type: str
 
 #: Suffix added to output files if specific output filename is not specified.
 OUTPUT_SUFFIX = {"encrypt": ".encrypted", "decrypt": ".decrypted"}  # type: Dict[str, str]

--- a/src/aws_encryption_sdk_cli/internal/master_key_parsing.py
+++ b/src/aws_encryption_sdk_cli/internal/master_key_parsing.py
@@ -177,6 +177,10 @@ def _parse_master_key_providers_from_args(*key_providers_info):
         info = copy.deepcopy(provider_info)
         provider = str(info.pop("provider"))
         key_ids = [str(key_id) for key_id in info.pop("key")]
+
+        # Some implementations require a key_ids parameter as part of the kwargs, so explicitly set it here.
+        info["key_ids"] = key_ids
+
         key_providers.append(_build_master_key_provider(provider=provider, key=key_ids, **info))
 
     return _assemble_master_key_providers(*key_providers)  # pylint: disable=no-value-for-parameter

--- a/src/aws_encryption_sdk_cli/internal/mypy_types.py
+++ b/src/aws_encryption_sdk_cli/internal/mypy_types.py
@@ -11,7 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 """Complex type constructions for use with mypy annotations."""
-# mypy types confuse pylint: disable=invalid-name
+# mypy types confuse pylint: disable=invalid-name, unsubscriptable-object
 try:  # Python 3.5.0 and 3.5.1 have incompatible typing modules
     import sys
     from typing import IO, Dict, List, Text, Union

--- a/src/aws_encryption_sdk_cli/key_providers.py
+++ b/src/aws_encryption_sdk_cli/key_providers.py
@@ -15,6 +15,7 @@ import copy
 
 import botocore.session
 from aws_encryption_sdk import DiscoveryAwsKmsMasterKeyProvider, StrictAwsKmsMasterKeyProvider
+from aws_encryption_sdk.key_providers.kms import DiscoveryFilter
 
 from aws_encryption_sdk_cli.exceptions import BadUserArgumentError
 from aws_encryption_sdk_cli.internal.identifiers import USER_AGENT_SUFFIX
@@ -68,5 +69,11 @@ def aws_kms_master_key_provider(discovery=True, **kwargs):
     except KeyError:
         pass
     if discovery:
+        accounts = kwargs.pop("discovery-account", None)
+        partition = kwargs.pop("discovery-partition", None)
+        if accounts and partition:
+            discovery_filter = DiscoveryFilter(account_ids=accounts, partition=partition)
+            kwargs["discovery_filter"] = discovery_filter  # type: ignore
+
         return DiscoveryAwsKmsMasterKeyProvider(**kwargs)
     return StrictAwsKmsMasterKeyProvider(**kwargs)

--- a/test/unit/internal/test_master_key_parsing.py
+++ b/test/unit/internal/test_master_key_parsing.py
@@ -220,8 +220,8 @@ def test_parse_master_key_providers_from_args(patch_build_master_key_provider, p
     )
     patch_build_master_key_provider.assert_has_calls(
         calls=(
-            call(provider="provider_1_a", key=["provider_info_1_b"]),
-            call(provider="provider_2_a", key=["provider_info_2_b"], z="additional_z"),
+            call(provider="provider_1_a", key=["provider_info_1_b"], key_ids=["provider_info_1_b"]),
+            call(provider="provider_2_a", key=["provider_info_2_b"], z="additional_z", key_ids=["provider_info_2_b"]),
         ),
         any_order=False,
     )

--- a/tox.ini
+++ b/tox.ini
@@ -12,8 +12,6 @@ envlist =
 # linters :: Runs all linters over all source code.
 # linters-tests :: Runs all linters over all tests.
 
-ignore_basepython_conflict = True
-
 # Autoformatter helper environments:
 # autoformat : Apply autoformatting
 # black-check : Check for "black" issues
@@ -32,7 +30,7 @@ ignore_basepython_conflict = True
 # release :: Builds dist files and uploads to pypi pypirc profile.
 
 [testenv]
-passenv = 
+passenv =
     # Identifies AWS KMS key id to use in integration tests
     AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_AWS_KMS_KEY_ID \
     # Pass through AWS credentials
@@ -269,7 +267,7 @@ commands =
 
 # Release tooling
 [testenv:park]
-basepython = python3.6
+basepython = python3.8
 skip_install = true
 deps =
     pypi-parker
@@ -294,13 +292,32 @@ deps =
     {[testenv:build]deps}
     twine
 passenv =
+    # Intentionally omit TWINE_REPOSITORY_URL from the passenv list,
+    # as this overrides other ways of setting the repository and could
+    # unexpectedly result in releasing to the wrong repo
     {[testenv]passenv} \
     TWINE_USERNAME \
-    TWINE_PASSWORD \
-    TWINE_REPOSITORY_URL
+    TWINE_PASSWORD
 commands =
     {[testenv:build]commands}
-    twine upload --skip-existing --repository testpypi dist/*
+    twine upload --skip-existing {toxinidir}/dist/*
+
+[testenv:release-private]
+basepython = python3
+skip_install = true
+deps = {[testenv:release-base]deps}
+passenv =
+    {[testenv:release-base]passenv} \
+    TWINE_REPOSITORY_URL
+setenv =
+    # Explicitly set the URL as the env variable value, which will cause us to
+    # throw an error if the variable is not set. Otherwise, omission of the
+    # env variable could cause us to unintentionally upload to the wrong repo
+    TWINE_REPOSITORY_URL = {env:TWINE_REPOSITORY_URL}
+commands =
+    {[testenv:release-base]commands}
+    # Omitting an explicit repository will cause twine to use the repository
+    # specified in the environment variable
 
 [testenv:test-release]
 basepython = python3
@@ -308,9 +325,8 @@ skip_install = true
 deps = {[testenv:release-base]deps}
 passenv =
     {[testenv:release-base]passenv}
-setenv =
-    TWINE_REPOSITORY_URL = https://test.pypi.org/legacy/
-commands = {[testenv:release-base]commands}
+commands =
+    {[testenv:release-base]commands}
 
 [testenv:release]
 basepython = python3
@@ -320,6 +336,4 @@ passenv =
     {[testenv:release-base]passenv}
 whitelist_externals = unset
 commands =
-    # Unsetting the TWINE_REPOSITORY_URL defaults twine to using production PyPI
-    unset TWINE_REPOSITORY_URL
     {[testenv:release-base]commands}


### PR DESCRIPTION
*Description of changes:*
  
This change includes fixes for enabling or disabling discovery mode in the CLI.
    
BREAKING CHANGE: --discovery parameter is removed. It is replaced by a ‘discovery’ attribute of --wrapping-keys parameter. Decrypt commands will fail if ‘discovery’ is used as a parameter. ‘discovery’ attribute is valid only in decrypt
commands where the provider is ‘aws-kms’. The command will fail if ‘discovery’ attribute is combined with any other provider.
    
See: https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/crypto-cli.html


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
