### PR TITLE
Fixes for enabling or disabling discovery mode in the CLI (2.x)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,18 @@
 Changelog
 *********
 
+2.1.0 -- 2020-10-27
+===================
+
+Bugfixes
+--------
+* Fix for enabling or disabling discovery mode in the CLI
+
+Breaking Changes
+----------------
+* The ``--discovery`` parameter is removed. It is replaced by a ``discovery`` attribute of the
+  ``--wrapping-keys`` parameter.
+
 2.0.0 -- 2020-09-24
 ===================
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 base64io>=1.0.1
-aws-encryption-sdk>=2.0.0
+aws-encryption-sdk~=2.0
 setuptools
 attrs>=17.1.0

--- a/src/aws_encryption_sdk_cli/__init__.py
+++ b/src/aws_encryption_sdk_cli/__init__.py
@@ -272,7 +272,6 @@ def cli(raw_args=None):
         _LOGGER.debug("Encryption source: %s", args.input)
         _LOGGER.debug("Encryption destination: %s", args.output)
         _LOGGER.debug("Wrapping key provider configuration: %s", args.wrapping_keys)
-        _LOGGER.debug("Discovery mode: %r", args.discovery)
         _LOGGER.debug("Suffix requested: %s", args.suffix)
 
         crypto_materials_manager = build_crypto_materials_manager_from_args(

--- a/src/aws_encryption_sdk_cli/internal/identifiers.py
+++ b/src/aws_encryption_sdk_cli/internal/identifiers.py
@@ -31,7 +31,7 @@ __all__ = (
     "DEFAULT_MASTER_KEY_PROVIDER",
     "OperationResult",
 )
-__version__ = "2.0.0"  # type: str
+__version__ = "2.1.0"  # type: str
 
 #: Suffix added to output files if specific output filename is not specified.
 OUTPUT_SUFFIX = {"encrypt": ".encrypted", "decrypt": ".decrypted"}  # type: Dict[str, str]

--- a/src/aws_encryption_sdk_cli/internal/master_key_parsing.py
+++ b/src/aws_encryption_sdk_cli/internal/master_key_parsing.py
@@ -177,6 +177,10 @@ def _parse_master_key_providers_from_args(*key_providers_info):
         info = copy.deepcopy(provider_info)
         provider = str(info.pop("provider"))
         key_ids = [str(key_id) for key_id in info.pop("key")]
+
+        # Some implementations require a key_ids parameter as part of the kwargs, so explicitly set it here.
+        info["key_ids"] = key_ids
+
         key_providers.append(_build_master_key_provider(provider=provider, key=key_ids, **info))
 
     return _assemble_master_key_providers(*key_providers)  # pylint: disable=no-value-for-parameter

--- a/src/aws_encryption_sdk_cli/key_providers.py
+++ b/src/aws_encryption_sdk_cli/key_providers.py
@@ -15,6 +15,7 @@ import copy
 
 import botocore.session
 from aws_encryption_sdk import DiscoveryAwsKmsMasterKeyProvider, StrictAwsKmsMasterKeyProvider
+from aws_encryption_sdk.key_providers.kms import DiscoveryFilter
 
 from aws_encryption_sdk_cli.exceptions import BadUserArgumentError
 from aws_encryption_sdk_cli.internal.identifiers import USER_AGENT_SUFFIX
@@ -68,5 +69,11 @@ def aws_kms_master_key_provider(discovery=True, **kwargs):
     except KeyError:
         pass
     if discovery:
+        accounts = kwargs.pop("discovery-account", None)
+        partition = kwargs.pop("discovery-partition", None)
+        if accounts and partition:
+            discovery_filter = DiscoveryFilter(account_ids=accounts, partition=partition)
+            kwargs["discovery_filter"] = discovery_filter  # type: ignore
+
         return DiscoveryAwsKmsMasterKeyProvider(**kwargs)
     return StrictAwsKmsMasterKeyProvider(**kwargs)

--- a/test/integration/integration_test_utils.py
+++ b/test/integration/integration_test_utils.py
@@ -72,8 +72,8 @@ def encrypt_args_template(metadata=False, caching=False, encode=False, decode=Fa
     return template
 
 
-def decrypt_args_template(metadata=False, encode=False, decode=False):
-    template = "-d -i {source} -o {target} --discovery=true"
+def decrypt_args_template(metadata=False, encode=False, decode=False, discovery=True):
+    template = "-d -i {source} -o {target} "
     if metadata:
         template += " {metadata}"
     else:
@@ -82,6 +82,8 @@ def decrypt_args_template(metadata=False, encode=False, decode=False):
         template += " --encode"
     if decode:
         template += " --decode"
+    if discovery:
+        template += " --wrapping-keys discovery=true"
     return template
 
 

--- a/test/integration/test_i_aws_encryption_sdk_cli.py
+++ b/test/integration/test_i_aws_encryption_sdk_cli.py
@@ -26,6 +26,7 @@ import aws_encryption_sdk_cli
 from .integration_test_utils import (
     WINDOWS_SKIP_MESSAGE,
     aws_encryption_cli_is_findable,
+    cmk_arn_value,
     decrypt_args_template,
     encrypt_args_template,
     is_windows,
@@ -128,6 +129,245 @@ def test_cycle_with_metadata_output_append(tmpdir):
     assert output_metadata[1]["input"] == str(ciphertext)
     assert output_metadata[1]["output"] == str(decrypted)
     assert "header_auth" in output_metadata[1]
+
+
+def test_cycle_explicit_discovery_true_no_filter(tmpdir):
+    plaintext = tmpdir.join("source_plaintext")
+    plaintext.write_binary(os.urandom(1024))
+    ciphertext = tmpdir.join("ciphertext")
+    decrypted = tmpdir.join("decrypted")
+    metadata = tmpdir.join("metadata")
+
+    encrypt_args = encrypt_args_template(metadata=True).format(
+        source=str(plaintext), target=str(ciphertext), metadata="--metadata-output " + str(metadata)
+    )
+    decrypt_args = decrypt_args_template(metadata=True, discovery=True).format(
+        source=str(ciphertext), target=str(decrypted), metadata="--metadata-output " + str(metadata)
+    )
+
+    aws_encryption_sdk_cli.cli(shlex.split(encrypt_args, posix=not is_windows()))
+    aws_encryption_sdk_cli.cli(shlex.split(decrypt_args, posix=not is_windows()))
+
+    output_metadata = [json.loads(line) for line in metadata.readlines()]
+    for line in output_metadata:
+        for key, value in (("a", "b"), ("c", "d")):
+            assert line["header"]["encryption_context"][key] == value
+
+    assert output_metadata[0]["mode"] == "encrypt"
+    assert output_metadata[0]["input"] == str(plaintext)
+    assert output_metadata[0]["output"] == str(ciphertext)
+    assert "header_auth" not in output_metadata[0]
+    assert output_metadata[1]["mode"] == "decrypt"
+    assert output_metadata[1]["input"] == str(ciphertext)
+    assert output_metadata[1]["output"] == str(decrypted)
+    assert "header_auth" in output_metadata[1]
+
+
+def test_cycle_discovery_true_filter_wrong_account(tmpdir):
+    plaintext = tmpdir.join("source_plaintext")
+    plaintext.write_binary(os.urandom(1024))
+    ciphertext = tmpdir.join("ciphertext")
+    decrypted = tmpdir.join("decrypted")
+    metadata = tmpdir.join("metadata")
+
+    encrypt_args = encrypt_args_template(metadata=True).format(
+        source=str(plaintext), target=str(ciphertext), metadata="--metadata-output " + str(metadata)
+    )
+    decrypt_args = decrypt_args_template(metadata=True, discovery=False).format(
+        source=str(ciphertext), target=str(decrypted), metadata="--metadata-output " + str(metadata)
+    )
+    decrypt_args += " -w discovery=true discovery-account=1234 discovery-partition=aws"
+
+    aws_encryption_sdk_cli.cli(shlex.split(encrypt_args, posix=not is_windows()))
+    message = aws_encryption_sdk_cli.cli(shlex.split(decrypt_args, posix=not is_windows()))
+
+    output_metadata = [json.loads(line) for line in metadata.readlines()]
+    for line in output_metadata:
+        for key, value in (("a", "b"), ("c", "d")):
+            assert line["header"]["encryption_context"][key] == value
+
+    assert output_metadata[0]["mode"] == "encrypt"
+    assert output_metadata[0]["input"] == str(plaintext)
+    assert output_metadata[0]["output"] == str(ciphertext)
+    assert "header_auth" not in output_metadata[0]
+    assert not decrypted.isfile()
+    assert "not allowed by this Master Key Provider" in message
+
+
+def test_cycle_discovery_true_filter_wrong_partition(tmpdir):
+    plaintext = tmpdir.join("source_plaintext")
+    plaintext.write_binary(os.urandom(1024))
+    ciphertext = tmpdir.join("ciphertext")
+    decrypted = tmpdir.join("decrypted")
+    metadata = tmpdir.join("metadata")
+
+    encrypt_args = encrypt_args_template(metadata=True).format(
+        source=str(plaintext), target=str(ciphertext), metadata="--metadata-output " + str(metadata)
+    )
+    decrypt_args = decrypt_args_template(metadata=True, discovery=False).format(
+        source=str(ciphertext), target=str(decrypted), metadata="--metadata-output " + str(metadata)
+    )
+    arn = cmk_arn_value()
+    account = arn.split(":")[4]
+    decrypt_args += " -w discovery=true discovery-account={account} discovery-partition=aws-gov".format(account=account)
+
+    aws_encryption_sdk_cli.cli(shlex.split(encrypt_args, posix=not is_windows()))
+    message = aws_encryption_sdk_cli.cli(shlex.split(decrypt_args, posix=not is_windows()))
+
+    output_metadata = [json.loads(line) for line in metadata.readlines()]
+    for line in output_metadata:
+        for key, value in (("a", "b"), ("c", "d")):
+            assert line["header"]["encryption_context"][key] == value
+
+    assert output_metadata[0]["mode"] == "encrypt"
+    assert output_metadata[0]["input"] == str(plaintext)
+    assert output_metadata[0]["output"] == str(ciphertext)
+    assert "header_auth" not in output_metadata[0]
+    assert not decrypted.isfile()
+    assert "not allowed by this Master Key Provider" in message
+
+
+def test_cycle_discovery_true_filter_correct(tmpdir):
+    plaintext = tmpdir.join("source_plaintext")
+    plaintext.write_binary(os.urandom(1024))
+    ciphertext = tmpdir.join("ciphertext")
+    decrypted = tmpdir.join("decrypted")
+    metadata = tmpdir.join("metadata")
+
+    encrypt_args = encrypt_args_template(metadata=True).format(
+        source=str(plaintext), target=str(ciphertext), metadata="--metadata-output " + str(metadata)
+    )
+    decrypt_args = decrypt_args_template(metadata=True).format(
+        source=str(ciphertext), target=str(decrypted), metadata="--metadata-output " + str(metadata)
+    )
+    arn = cmk_arn_value().split(":")
+    account = arn[4]
+    partition = arn[1]
+    decrypt_args += " -w discovery=true discovery-account={account} discovery-partition={partition}".format(
+        account=account, partition=partition
+    )
+
+    aws_encryption_sdk_cli.cli(shlex.split(encrypt_args, posix=not is_windows()))
+    aws_encryption_sdk_cli.cli(shlex.split(decrypt_args, posix=not is_windows()))
+
+    output_metadata = [json.loads(line) for line in metadata.readlines()]
+    for line in output_metadata:
+        for key, value in (("a", "b"), ("c", "d")):
+            assert line["header"]["encryption_context"][key] == value
+
+    assert output_metadata[0]["mode"] == "encrypt"
+    assert output_metadata[0]["input"] == str(plaintext)
+    assert output_metadata[0]["output"] == str(ciphertext)
+    assert "header_auth" not in output_metadata[0]
+    assert output_metadata[1]["mode"] == "decrypt"
+    assert output_metadata[1]["input"] == str(ciphertext)
+    assert output_metadata[1]["output"] == str(decrypted)
+    assert "header_auth" in output_metadata[1]
+
+
+def test_cycle_discovery_true_filter_multiple_accounts_correct(tmpdir):
+    plaintext = tmpdir.join("source_plaintext")
+    plaintext.write_binary(os.urandom(1024))
+    ciphertext = tmpdir.join("ciphertext")
+    decrypted = tmpdir.join("decrypted")
+    metadata = tmpdir.join("metadata")
+
+    encrypt_args = encrypt_args_template(metadata=True).format(
+        source=str(plaintext), target=str(ciphertext), metadata="--metadata-output " + str(metadata)
+    )
+    decrypt_args = decrypt_args_template(metadata=True).format(
+        source=str(ciphertext), target=str(decrypted), metadata="--metadata-output " + str(metadata)
+    )
+    arn = cmk_arn_value().split(":")
+    account = arn[4]
+    partition = arn[1]
+    decrypt_args += (
+        " -w discovery=true discovery-account=123 discovery-account={account} discovery-partition={partition}".format(
+            account=account, partition=partition
+        )
+    )
+
+    aws_encryption_sdk_cli.cli(shlex.split(encrypt_args, posix=not is_windows()))
+    aws_encryption_sdk_cli.cli(shlex.split(decrypt_args, posix=not is_windows()))
+
+    output_metadata = [json.loads(line) for line in metadata.readlines()]
+    for line in output_metadata:
+        for key, value in (("a", "b"), ("c", "d")):
+            assert line["header"]["encryption_context"][key] == value
+
+    assert output_metadata[0]["mode"] == "encrypt"
+    assert output_metadata[0]["input"] == str(plaintext)
+    assert output_metadata[0]["output"] == str(ciphertext)
+    assert "header_auth" not in output_metadata[0]
+    assert output_metadata[1]["mode"] == "decrypt"
+    assert output_metadata[1]["input"] == str(ciphertext)
+    assert output_metadata[1]["output"] == str(decrypted)
+    assert "header_auth" in output_metadata[1]
+
+
+def test_cycle_discovery_false(tmpdir):
+    plaintext = tmpdir.join("source_plaintext")
+    plaintext.write_binary(os.urandom(1024))
+    ciphertext = tmpdir.join("ciphertext")
+    decrypted = tmpdir.join("decrypted")
+    metadata = tmpdir.join("metadata")
+
+    encrypt_args = encrypt_args_template(metadata=True).format(
+        source=str(plaintext), target=str(ciphertext), metadata="--metadata-output " + str(metadata)
+    )
+    decrypt_args = decrypt_args_template(metadata=True, discovery=False).format(
+        source=str(ciphertext), target=str(decrypted), metadata="--metadata-output " + str(metadata)
+    )
+    decrypt_args += " -w discovery=false key=" + cmk_arn_value()
+
+    aws_encryption_sdk_cli.cli(shlex.split(encrypt_args, posix=not is_windows()))
+    aws_encryption_sdk_cli.cli(shlex.split(decrypt_args, posix=not is_windows()))
+
+    output_metadata = [json.loads(line) for line in metadata.readlines()]
+    for line in output_metadata:
+        for key, value in (("a", "b"), ("c", "d")):
+            assert line["header"]["encryption_context"][key] == value
+
+    assert output_metadata[0]["mode"] == "encrypt"
+    assert output_metadata[0]["input"] == str(plaintext)
+    assert output_metadata[0]["output"] == str(ciphertext)
+    assert "header_auth" not in output_metadata[0]
+    assert output_metadata[1]["mode"] == "decrypt"
+    assert output_metadata[1]["input"] == str(ciphertext)
+    assert output_metadata[1]["output"] == str(decrypted)
+    assert "header_auth" in output_metadata[1]
+
+
+def test_cycle_discovery_false_wrong_key_id(tmpdir):
+    plaintext = tmpdir.join("source_plaintext")
+    plaintext.write_binary(os.urandom(1024))
+    ciphertext = tmpdir.join("ciphertext")
+    decrypted = tmpdir.join("decrypted")
+    metadata = tmpdir.join("metadata")
+
+    encrypt_args = encrypt_args_template(metadata=True).format(
+        source=str(plaintext), target=str(ciphertext), metadata="--metadata-output " + str(metadata)
+    )
+    decrypt_args = decrypt_args_template(metadata=True, discovery=False).format(
+        source=str(ciphertext), target=str(decrypted), metadata="--metadata-output " + str(metadata)
+    )
+    wrong_key = cmk_arn_value()[:-1]
+    decrypt_args += " -w discovery=false key=" + wrong_key
+
+    aws_encryption_sdk_cli.cli(shlex.split(encrypt_args, posix=not is_windows()))
+    message = aws_encryption_sdk_cli.cli(shlex.split(decrypt_args, posix=not is_windows()))
+
+    output_metadata = [json.loads(line) for line in metadata.readlines()]
+    for line in output_metadata:
+        for key, value in (("a", "b"), ("c", "d")):
+            assert line["header"]["encryption_context"][key] == value
+
+    assert output_metadata[0]["mode"] == "encrypt"
+    assert output_metadata[0]["input"] == str(plaintext)
+    assert output_metadata[0]["output"] == str(ciphertext)
+    assert "header_auth" not in output_metadata[0]
+    assert not decrypted.isfile()
+    assert "Unable to decrypt any data key" in message
 
 
 @pytest.mark.parametrize("required_encryption_context", ("a", "c", "a c", "a=b", "a=b c", "c=d", "a c=d", "a=b c=d"))

--- a/test/unit/internal/test_master_key_parsing.py
+++ b/test/unit/internal/test_master_key_parsing.py
@@ -220,8 +220,8 @@ def test_parse_master_key_providers_from_args(patch_build_master_key_provider, p
     )
     patch_build_master_key_provider.assert_has_calls(
         calls=(
-            call(provider="provider_1_a", key=["provider_info_1_b"]),
-            call(provider="provider_2_a", key=["provider_info_2_b"], z="additional_z"),
+            call(provider="provider_1_a", key=["provider_info_1_b"], key_ids=["provider_info_1_b"]),
+            call(provider="provider_2_a", key=["provider_info_2_b"], z="additional_z", key_ids=["provider_info_2_b"]),
         ),
         any_order=False,
     )

--- a/test/unit/test_aws_encryption_sdk_cli.py
+++ b/test/unit/test_aws_encryption_sdk_cli.py
@@ -733,7 +733,7 @@ def test_cli_unknown_error_capture_stacktrace(patch_process_cli_request, tmpdir,
             + str(tmpdir.join("ciphertext"))
             + " "
             + requested_log_level
-            + " --discovery=true"
+            + " -w discovery=true"
         )
     )
 


### PR DESCRIPTION
*Description of changes:*
This change includes fixes for enabling or disabling discovery mode in the CLI.

BREAKING CHANGE: --discovery parameter is removed. It is replaced by a ‘discovery’ attribute of --wrapping-keys parameter. Decrypt commands will fail if ‘discovery’ is used as a parameter. ‘discovery’ attribute is valid only in decrypt
commands where the provider is ‘aws-kms’. The command will fail if ‘discovery’ attribute is combined with any other provider.

See: https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/crypto-cli.html



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
