### PR TITLE
chore: Add dedicated code coverage tox environment

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -13,3 +13,6 @@ batch:
       buildspec: codebuild/python_37.yml
     - identifier: python_38
       buildspec: codebuild/python_38.yml
+
+    - identifier: code_coverage
+      buildspec: codebuild/coverage.yml

--- a/codebuild/coverage.yml
+++ b/codebuild/coverage.yml
@@ -1,0 +1,16 @@
+version: 0.2
+
+env:
+  variables:
+    TOXENV: "coverage"
+    AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_AWS_KMS_KEY_ID: >-
+      arn:aws:kms:us-west-2:658956600833:key/b3537ef1-d8dc-4780-9f5a-55776cbb2f7f
+
+phases:
+  install:
+    runtime-versions:
+      python: latest
+  build:
+    commands:
+      - pip install tox
+      - tox

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,7 @@ branch = True
 
 [coverage:report]
 show_missing = True
+fail_under = 70
 
 [mypy]
 ignore_missing_imports = True

--- a/tox.ini
+++ b/tox.ini
@@ -29,6 +29,10 @@ envlist =
 # test-release :: Builds dist files and uploads to testpypi pypirc profile.
 # release :: Builds dist files and uploads to pypi pypirc profile.
 
+# Reporting environments:
+#
+# coverage :: Runs code coverage, failing the build if coverage is below the configured threshold
+
 [testenv]
 passenv = 
     # Identifies AWS KMS key id to use in integration tests
@@ -49,9 +53,13 @@ deps =
     pytest-cov
     pytest-mock
 commands =
-    local: pytest --cov aws_encryption_sdk_cli -m local -l test/ {posargs}
-    integ: pytest --cov aws_encryption_sdk_cli -m integ -l test/ {posargs}
+    local: pytest -m local -l test/ {posargs}
+    integ: pytest -m integ -l test/ {posargs}
     all: pytest --cov aws_encryption_sdk_cli -l test/ {posargs}
+
+# Run code coverage on the unit tests
+[testenv:coverage]
+commands = pytest --cov aws_encryption_sdk test/
 
 # mypy
 [testenv:mypy-coverage]


### PR DESCRIPTION
*Description of changes:*
Remove code coverage from default python commands, add a dedicated code coverage environment, as well as code build specs to run it.

See also https://github.com/aws/aws-encryption-sdk-python/pull/325, https://github.com/aws/aws-dynamodb-encryption-python/pull/153

Differences from the other PRs:
* CLI's code coverage isn't as good, so I have to set the threshold a fair bit lower
* Because of above, I'm including both integ and unit tests in the coverage check

*Testing:*
Confirmed build fails if I try to set the coverage threshold higher.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
