### PR TITLE
fix: New pytest warning “consider-using-with”

### DIFF
--- a/src/aws_encryption_sdk_cli/internal/io_handling.py
+++ b/src/aws_encryption_sdk_cli/internal/io_handling.py
@@ -265,6 +265,7 @@ class IOHandler(object):
             if not self._should_write_file(destination):
                 return OperationResult.SKIPPED
             _ensure_dir_exists(destination)
+            # pylint: disable=consider-using-with
             destination_writer = open(os.path.abspath(destination), "wb")
 
         if source == "-":

--- a/src/aws_encryption_sdk_cli/internal/metadata.py
+++ b/src/aws_encryption_sdk_cli/internal/metadata.py
@@ -105,6 +105,7 @@ class MetadataWriter(object):
                 # mypy insists that by this point that output_file can be None
                 # That potentiality is addressed by the initial constructor logic,
                 # but I can't figure out how to tell mypy that.
+                # pylint: disable=consider-using-with
                 self._output_stream = open(self.output_file, self._output_mode)  # type: ignore
 
     def __enter__(self):

--- a/test/integration/test_i_aws_encryption_sdk_cli.py
+++ b/test/integration/test_i_aws_encryption_sdk_cli.py
@@ -583,11 +583,11 @@ def test_stdin_to_file_to_stdout_cycle(tmpdir):
         source=str(ciphertext_file), target="-"
     )
 
-    proc = Popen(shlex.split(encrypt_args, posix=not is_windows()), stdout=PIPE, stdin=PIPE, stderr=PIPE)
-    _stdout, _stderr = proc.communicate(input=base64.b64encode(plaintext))
+    with Popen(shlex.split(encrypt_args, posix=not is_windows()), stdout=PIPE, stdin=PIPE, stderr=PIPE) as proc:
+        _stdout, _stderr = proc.communicate(input=base64.b64encode(plaintext))
 
-    proc = Popen(shlex.split(decrypt_args, posix=not is_windows()), stdout=PIPE, stdin=PIPE, stderr=PIPE)
-    decrypted_stdout, _stderr = proc.communicate()
+    with Popen(shlex.split(decrypt_args, posix=not is_windows()), stdout=PIPE, stdin=PIPE, stderr=PIPE) as proc:
+        decrypted_stdout, _stderr = proc.communicate()
 
     assert base64.b64decode(decrypted_stdout) == plaintext
 
@@ -602,10 +602,10 @@ def test_stdin_stdout_stdin_stdout_cycle():
     decrypt_args = "aws-encryption-cli " + decrypt_args_template(decode=True, encode=True).format(
         source="-", target="-"
     )
-    proc = Popen(shlex.split(encrypt_args, posix=not is_windows()), stdout=PIPE, stdin=PIPE, stderr=PIPE)
-    ciphertext, _stderr = proc.communicate(input=base64.b64encode(plaintext))
-    proc = Popen(shlex.split(decrypt_args, posix=not is_windows()), stdout=PIPE, stdin=PIPE, stderr=PIPE)
-    decrypted_stdout, _stderr = proc.communicate(input=ciphertext)
+    with Popen(shlex.split(encrypt_args, posix=not is_windows()), stdout=PIPE, stdin=PIPE, stderr=PIPE) as proc:
+        ciphertext, _stderr = proc.communicate(input=base64.b64encode(plaintext))
+    with Popen(shlex.split(decrypt_args, posix=not is_windows()), stdout=PIPE, stdin=PIPE, stderr=PIPE) as proc:
+        decrypted_stdout, _stderr = proc.communicate(input=ciphertext)
 
     assert base64.b64decode(decrypted_stdout) == plaintext
 
@@ -629,8 +629,8 @@ def test_file_to_stdout_decrypt_required_encryption_context_fail(tmpdir, require
     )
 
     aws_encryption_sdk_cli.cli(shlex.split(encrypt_args, posix=not is_windows()))
-    proc = Popen(shlex.split(decrypt_args, posix=not is_windows()), stdout=PIPE, stdin=PIPE, stderr=PIPE)
-    decrypted_output, stderr = proc.communicate()
+    with Popen(shlex.split(decrypt_args, posix=not is_windows()), stdout=PIPE, stdin=PIPE, stderr=PIPE) as proc:
+        decrypted_output, stderr = proc.communicate()
 
     # Verify that no output was written
     assert decrypted_output == b""


### PR DESCRIPTION
Hits in source code were both false positives (since both were non-trivial control flow and already handling closing the resources).

Hits in test code were reasonable to refactor to use `with`, but `Popen` only supports use as a resource as of Python 3.4, so we'll have to wait on that for now.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
