### PR TITLE
chore: Release using codebuild

### DIFF
--- a/api_compatibility_tests/compatibility-requirements/1.9.0
+++ b/api_compatibility_tests/compatibility-requirements/1.9.0
@@ -1,0 +1,1 @@
+aws-encryption-sdk-cli==1.9.0

--- a/api_compatibility_tests/compatibility-requirements/2.2.0
+++ b/api_compatibility_tests/compatibility-requirements/2.2.0
@@ -1,0 +1,1 @@
+aws-encryption-sdk-cli==2.2.0

--- a/api_compatibility_tests/tox.ini
+++ b/api_compatibility_tests/tox.ini
@@ -1,21 +1,31 @@
 [tox]
 envlist =
-    # Only include released versions by default
-    py38-awses_cli_{1.7.0,2.0.0}
+    py38-awses_cli_{1.7.0,1.8.0,1.9.0,2.0.0,2.1.0,2.2.0}
 
 [testenv:base-command]
 commands = pytest --basetemp={envtmpdir} -l test/ {posargs}
 
 [testenv]
 passenv =
-    AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_AWS_KMS_KEY_ID
+    # Identifies AWS KMS key id to use in integration tests
+    AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_AWS_KMS_KEY_ID \
+    # Pass through AWS credentials
+    AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN \
+    # AWS Role access in CodeBuild is via the contaner URI
+    AWS_CONTAINER_CREDENTIALS_RELATIVE_URI \
+    # Pass through AWS profile name (useful for local testing)
+    AWS_PROFILE \
+    # Pass through custom pip config file settings
+    PIP_CONFIG_FILE
 sitepackages = False
 deps =
     -rtest/requirements.txt
     awses_cli_1.7.0: -rcompatibility-requirements/1.7.0
     awses_cli_1.8.0: -rcompatibility-requirements/1.8.0
+    awses_cli_1.9.0: -rcompatibility-requirements/1.9.0
     awses_cli_2.0.0: -rcompatibility-requirements/2.0.0
     awses_cli_2.1.0: -rcompatibility-requirements/2.1.0
+    awses_cli_2.2.0: -rcompatibility-requirements/2.2.0
     awses_cli_local: -e {env:AWSES_CLI_LOCAL_PATH}
 commands = 
     {[testenv:base-command]commands}

--- a/codebuild/release/prod-release.yml
+++ b/codebuild/release/prod-release.yml
@@ -1,0 +1,41 @@
+version: 0.2
+
+env:
+  variables:
+    BRANCH: "master"
+  secrets-manager:
+    TWINE_USERNAME: PyPiAdmin:username 
+    TWINE_PASSWORD: PyPiAdmin:password
+
+phases:
+  install:
+    commands:
+      - pip install tox
+      - pip install --upgrade pip
+    runtime-versions:
+      python: latest
+  pre_build:
+    commands:
+      - git checkout $COMMIT_ID
+      - FOUND_VERSION=$(sed -n 's/__version__ = "\(.*\)"/\1/p' src/aws_encryption_sdk_cli/internal/identifiers.py)
+      - |
+        if expr ${FOUND_VERSION} != ${VERSION}; then
+          echo "identifiers.py version (${FOUND_VERSION}) does not match expected version (${VERSION}), stopping"
+          exit 1;
+        fi
+  build:
+    commands:
+      - tox -e park
+      - tox -e release
+
+batch:
+  fast-fail: true 
+  build-graph:
+    - identifier: release_to_prod
+    - identifier: validate_prod_release
+      depend-on:
+        - release_to_prod
+      buildspec: codebuild/release/validate.yml
+      env:
+        variables:
+          PIP_INDEX_URL: https://pypi.python.org/simple/

--- a/codebuild/release/test-release.yml
+++ b/codebuild/release/test-release.yml
@@ -1,0 +1,43 @@
+version: 0.2
+
+env:
+  variables:
+    BRANCH: "master"
+  secrets-manager:
+    TWINE_USERNAME: TestPyPiCryptoTools:username 
+    TWINE_PASSWORD: TestPyPiCryptoTools:password
+
+phases:
+  install:
+    commands:
+      - pip install tox
+      - pip install --upgrade pip
+    runtime-versions:
+      python: latest
+  pre_build:
+    commands:
+      - git checkout $COMMIT_ID
+      - FOUND_VERSION=$(sed -n 's/__version__ = "\(.*\)"/\1/p' src/aws_encryption_sdk_cli/internal/identifiers.py)
+      - |
+        if expr ${FOUND_VERSION} != ${VERSION}; then
+          echo "identifiers.py version (${FOUND_VERSION}) does not match expected version (${VERSION}), stopping"
+          exit 1;
+        fi
+  build:
+    commands:
+      - tox -e park
+      - tox -e test-release
+
+
+batch:
+  fast-fail: true
+  build-graph:
+    - identifier: release_to_staging
+    - identifier: validate_staging_release
+      depend-on:
+        - release_to_staging
+      buildspec: codebuild/release/validate.yml
+      env:
+        variables:
+          PIP_INDEX_URL: https://test.pypi.org/simple/
+          PIP_EXTRA_INDEX_URL: https://pypi.python.org/simple/

--- a/codebuild/release/validate.yml
+++ b/codebuild/release/validate.yml
@@ -1,0 +1,19 @@
+version: 0.2
+
+env:
+  variables:
+    AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_AWS_KMS_KEY_ID: >-
+      arn:aws:kms:us-west-2:658956600833:key/b3537ef1-d8dc-4780-9f5a-55776cbb2f7f
+
+phases:
+  install:
+    commands:
+      - pip install tox
+    runtime-versions:
+      python: latest
+  pre_build:
+    commands:
+      - cd api_compatibility_tests
+  build:
+    commands:
+      - tox -e py38-awses_cli_${VERSION}


### PR DESCRIPTION
Applying the same structure as we already have in the https://github.com/aws/aws-encrytion-sdk-python repo.

(cherry picked from commit 11d4c9d9032aca631ebe9655bc1da65cdf5db11a)

*Description of changes:* Back-port #206 to 1.x branch.

Local General Testing:
```
for MINOR_VERSION in 2.7 3.5 3.6 3.7 3.8 ;do
  pyenv local $(pyenv versions | grep "^  ${MINOR_VERSION}" | tail -1);
  PY_TOX=$(echo $MINOR_VERSION | sed 's/\.//');
  PIP_CONFIG_FILE=./private-pypi.config tox -re py$PY_TOX-integ,py$PY_TOX-local -p 2;
done
---
✔ OK py27-local in 14.392 seconds
✔ OK py27-integ in 1 minute, 5.111 seconds
✔ OK py35-local in 13.474 seconds
✔ OK py35-integ in 50.822 seconds
✔ OK py36-local in 13.657 seconds
✔ OK py36-integ in 49.361 seconds
✔ OK py37-local in 12.59 seconds
✔ OK py37-integ in 47.491 seconds
✔ OK py38-local in 12.439 seconds
✔ OK py38-integ in 46.512 seconds
```

Local Specific testing:
```
cd api_compatibility_tests;
tox -r -p 15 --skip-missing-interpreters;
---
  py38-awses_cli_1.7.0: commands succeeded
  py38-awses_cli_1.8.0: commands succeeded
ERROR:   py38-awses_cli_1.9.0: parallel child exit code 1
  py38-awses_cli_2.0.0: commands succeeded
  py38-awses_cli_2.1.0: commands succeeded
ERROR:   py38-awses_cli_2.2.0: parallel child exit code 1
```

1.9.0 and 2.2.0 Failures are expected.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
