### PR TITLE
chore: Fix test release tox target

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -310,7 +310,6 @@ passenv =
     TWINE_PASSWORD
 commands =
     {[testenv:build]commands}
-    twine upload --skip-existing {toxinidir}/dist/*
 
 [testenv:release-private]
 basepython = python3
@@ -328,6 +327,7 @@ commands =
     {[testenv:release-base]commands}
     # Omitting an explicit repository will cause twine to use the repository
     # specified in the environment variable
+    twine upload --skip-existing {toxinidir}/dist/*
 
 [testenv:test-release]
 basepython = python3
@@ -337,6 +337,7 @@ passenv =
     {[testenv:release-base]passenv}
 commands =
     {[testenv:release-base]commands}
+    twine upload --skip-existing --repository testpypi {toxinidir}/dist/*
 
 [testenv:release]
 basepython = python3
@@ -347,3 +348,4 @@ passenv =
 whitelist_externals = unset
 commands =
     {[testenv:release-base]commands}
+    twine upload --skip-existing --repository pypi {toxinidir}/dist/*


### PR DESCRIPTION
*Description of changes:*
This matches what we're doing in Python, which is successfully releasing to both Test and Prod: https://github.com/aws/aws-encryption-sdk-python/blob/master/tox.ini#L383-L401

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
