### PR TITLE
chore: Make release validation robust to transient failures

### DIFF
--- a/codebuild/release/validate.yml
+++ b/codebuild/release/validate.yml
@@ -16,4 +16,20 @@ phases:
       - cd api_compatibility_tests
   build:
     commands:
-      - tox -e py38-awses_cli_${VERSION}
+      - NUM_RETRIES=3
+      - |
+        while [ $NUM_RETRIES -gt 0 ]
+        do
+          tox -e py38-awses_cli_${VERSION}
+          if [ $? -eq 0 ]; then
+            break
+          fi
+          NUM_RETRIES=$((NUM_RETRIES-1))
+          if [ $NUM_RETRIES -eq 0 ]; then
+            echo "All validation attempts failed, stopping"
+            exit 1;
+          else
+            echo "Validation failed, retrying in 60 seconds; will retry $NUM_RETRIES more times" && sleep 60
+          fi
+        done
+

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -11,7 +11,7 @@ HERE = os.path.abspath(os.path.dirname(__file__))
 
 def read(*args):
     """Reads complete file contents."""
-    return io.open(os.path.join(HERE, *args), encoding="utf-8").read()
+    return io.open(os.path.join(HERE, *args), encoding="utf-8").read()  # pylint: disable=consider-using-with
 
 
 def get_release():

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ HERE = os.path.abspath(os.path.dirname(__file__))
 
 def read(*args):
     """Reads complete file contents."""
-    return io.open(os.path.join(HERE, *args), encoding="utf-8").read()
+    return io.open(os.path.join(HERE, *args), encoding="utf-8").read()  # pylint: disable=consider-using-with
 
 
 def get_version():

--- a/src/aws_encryption_sdk_cli/__init__.py
+++ b/src/aws_encryption_sdk_cli/__init__.py
@@ -268,13 +268,13 @@ def cli(raw_args=None):
     try:
         args = parse_args(raw_args)
 
-        setup_logger(args.verbosity, args.quiet)
+        setup_logger(args.verbosity, args.quiet)  # pylint: disable=no-member
 
-        _LOGGER.debug("Encryption mode: %s", args.action)
-        _LOGGER.debug("Encryption source: %s", args.input)
-        _LOGGER.debug("Encryption destination: %s", args.output)
-        _LOGGER.debug("Wrapping key provider configuration: %s", args.wrapping_keys)
-        _LOGGER.debug("Suffix requested: %s", args.suffix)
+        _LOGGER.debug("Encryption mode: %s", args.action)  # pylint: disable=no-member
+        _LOGGER.debug("Encryption source: %s", args.input)  # pylint: disable=no-member
+        _LOGGER.debug("Encryption destination: %s", args.output)  # pylint: disable=no-member
+        _LOGGER.debug("Wrapping key provider configuration: %s", args.wrapping_keys)  # pylint: disable=no-member
+        _LOGGER.debug("Suffix requested: %s", args.suffix)  # pylint: disable=no-member
 
         crypto_materials_manager = build_crypto_materials_manager_from_args(
             key_providers_config=args.wrapping_keys, caching_config=args.caching

--- a/src/aws_encryption_sdk_cli/internal/io_handling.py
+++ b/src/aws_encryption_sdk_cli/internal/io_handling.py
@@ -374,7 +374,7 @@ class IOHandler(object):
             operation_result = OperationResult.FAILED
             raise
         finally:
-            if operation_result.needs_cleanup and destination != "-":
+            if operation_result.needs_cleanup and destination != "-":  # pylint: disable=no-member
                 _LOGGER.warning("Operation failed: deleting output file: %s", destination)
                 try:
                     os.remove(destination)


### PR DESCRIPTION
*Description of changes:*
Same as we just did for Python ESDK https://github.com/aws/aws-encryption-sdk-python/pull/344

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
