### PR TITLE
feat: AWS KMS multi-Region Key support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,24 @@
 Changelog
 *********
 
+3.0.0 -- 2021-06-16
+===================
+
+Features
+--------
+* AWS KMS multi-Region Key support
+
+  CLI now supports Multi-Region Keys (MRKs).
+  Usage of MRKs is identical to the usage of non-MRK KMS Keys.
+  Though a KMS Key does not have to be a MRK key for it to be used.
+
+  See https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview.html
+  for more details about AWS KMS multi-Region Keys.
+
+  See https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/configure.html#config-mrks
+  for more details about how the AWS Encryption SDK interoperates
+  with AWS KMS multi-Region keys.
+
 2.2.0 -- 2021-05-27
 ===================
 

--- a/api_compatibility_tests/compatibility-requirements/3.0.0
+++ b/api_compatibility_tests/compatibility-requirements/3.0.0
@@ -1,0 +1,1 @@
+aws-encryption-sdk-cli==3.0.0

--- a/api_compatibility_tests/tox.ini
+++ b/api_compatibility_tests/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py38-awses_cli_{1.7.0,1.8.0,1.9.0,2.0.0,2.1.0,2.2.0}
+    py38-awses_cli_{1.7.0,1.8.0,1.9.0,2.0.0,2.1.0,2.2.0,3.0.0}
 
 [testenv:base-command]
 commands = pytest --basetemp={envtmpdir} -l test/ {posargs}
@@ -26,6 +26,7 @@ deps =
     awses_cli_2.0.0: -rcompatibility-requirements/2.0.0
     awses_cli_2.1.0: -rcompatibility-requirements/2.1.0
     awses_cli_2.2.0: -rcompatibility-requirements/2.2.0
+    awses_cli_3.0.0: -rcompatibility-requirements/3.0.0
     awses_cli_local: -e {env:AWSES_CLI_LOCAL_PATH}
 commands = 
     {[testenv:base-command]commands}

--- a/codebuild/python_27.yml
+++ b/codebuild/python_27.yml
@@ -5,6 +5,8 @@ env:
     TOXENV: "py27-integ"
     AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_AWS_KMS_KEY_ID: >-
       arn:aws:kms:us-west-2:658956600833:key/b3537ef1-d8dc-4780-9f5a-55776cbb2f7f
+    AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_AWS_KMS_MRK_KEY_ID_1: >-
+      arn:aws:kms:us-east-1:658956600833:key/mrk-80bd8ecdcd4342aebd84b7dc9da498a7
 
 phases:
   install:

--- a/codebuild/python_35.yml
+++ b/codebuild/python_35.yml
@@ -5,6 +5,8 @@ env:
     TOXENV: "py35-integ"
     AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_AWS_KMS_KEY_ID: >-
       arn:aws:kms:us-west-2:658956600833:key/b3537ef1-d8dc-4780-9f5a-55776cbb2f7f
+    AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_AWS_KMS_MRK_KEY_ID_1: >-
+      arn:aws:kms:us-east-1:658956600833:key/mrk-80bd8ecdcd4342aebd84b7dc9da498a7
 
 phases:
   install:

--- a/codebuild/python_36.yml
+++ b/codebuild/python_36.yml
@@ -5,6 +5,8 @@ env:
     TOXENV: "py36-integ"
     AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_AWS_KMS_KEY_ID: >-
       arn:aws:kms:us-west-2:658956600833:key/b3537ef1-d8dc-4780-9f5a-55776cbb2f7f
+    AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_AWS_KMS_MRK_KEY_ID_1: >-
+      arn:aws:kms:us-east-1:658956600833:key/mrk-80bd8ecdcd4342aebd84b7dc9da498a7
 
 phases:
   install:

--- a/codebuild/python_37.yml
+++ b/codebuild/python_37.yml
@@ -5,6 +5,8 @@ env:
     TOXENV: "py37-integ"
     AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_AWS_KMS_KEY_ID: >-
       arn:aws:kms:us-west-2:658956600833:key/b3537ef1-d8dc-4780-9f5a-55776cbb2f7f
+    AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_AWS_KMS_MRK_KEY_ID_1: >-
+      arn:aws:kms:us-east-1:658956600833:key/mrk-80bd8ecdcd4342aebd84b7dc9da498a7
 
 phases:
   install:

--- a/codebuild/python_38.yml
+++ b/codebuild/python_38.yml
@@ -5,6 +5,8 @@ env:
     TOXENV: "py38-integ"
     AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_AWS_KMS_KEY_ID: >-
       arn:aws:kms:us-west-2:658956600833:key/b3537ef1-d8dc-4780-9f5a-55776cbb2f7f
+    AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_AWS_KMS_MRK_KEY_ID_1: >-
+      arn:aws:kms:us-east-1:658956600833:key/mrk-80bd8ecdcd4342aebd84b7dc9da498a7
 
 phases:
   install:

--- a/codebuild/release/validate.yml
+++ b/codebuild/release/validate.yml
@@ -4,6 +4,8 @@ env:
   variables:
     AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_AWS_KMS_KEY_ID: >-
       arn:aws:kms:us-west-2:658956600833:key/b3537ef1-d8dc-4780-9f5a-55776cbb2f7f
+    AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_AWS_KMS_MRK_KEY_ID_1: >-
+      arn:aws:kms:us-east-1:658956600833:key/mrk-80bd8ecdcd4342aebd84b7dc9da498a7
 
 phases:
   install:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 base64io>=1.0.1
-aws-encryption-sdk~=2.2
+aws-encryption-sdk~=2.3
 setuptools
 attrs>=17.1.0

--- a/src/aws_encryption_sdk_cli/internal/identifiers.py
+++ b/src/aws_encryption_sdk_cli/internal/identifiers.py
@@ -31,7 +31,7 @@ __all__ = (
     "DEFAULT_MASTER_KEY_PROVIDER",
     "OperationResult",
 )
-__version__ = "2.2.0"  # type: str
+__version__ = "3.0.0"  # type: str
 
 #: Suffix added to output files if specific output filename is not specified.
 OUTPUT_SUFFIX = {

--- a/src/aws_encryption_sdk_cli/key_providers.py
+++ b/src/aws_encryption_sdk_cli/key_providers.py
@@ -14,8 +14,11 @@
 import copy
 
 import botocore.session
-from aws_encryption_sdk import DiscoveryAwsKmsMasterKeyProvider, StrictAwsKmsMasterKeyProvider
-from aws_encryption_sdk.key_providers.kms import DiscoveryFilter
+from aws_encryption_sdk.key_providers.kms import (
+    DiscoveryFilter,
+    MRKAwareDiscoveryAwsKmsMasterKeyProvider,
+    MRKAwareStrictAwsKmsMasterKeyProvider,
+)
 
 from aws_encryption_sdk_cli.exceptions import BadUserArgumentError
 from aws_encryption_sdk_cli.internal.identifiers import USER_AGENT_SUFFIX
@@ -29,13 +32,16 @@ except ImportError:  # pragma: no cover
 __all__ = ("aws_kms_master_key_provider",)
 
 
-def aws_kms_master_key_provider(discovery=True, **kwargs):
-    # type: (bool, **List[Union[Text, str]]) -> Union[DiscoveryAwsKmsMasterKeyProvider, StrictAwsKmsMasterKeyProvider]
+def aws_kms_master_key_provider(
+    discovery=True,  # type: bool
+    **kwargs  # type: List[Union[Text, str]]
+):
+    # type: (...) -> Union[MRKAwareDiscoveryAwsKmsMasterKeyProvider, MRKAwareStrictAwsKmsMasterKeyProvider]
     """Apply post-processing to transform ``KMSMasterKeyProvider``-specific values from CLI
-    arguments to valid ``KMSMasterKeyProvider`` parameters, then call ``KMSMasterKeyprovider``
+    arguments to valid ``KMSMasterKeyProvider`` parameters, then call ``KMSMasterKeyProvider``
     with those parameters.
 
-    :param bool discovery: Return a DiscoveryAwsKmsMasterKeyProvider
+    :param bool discovery: Return a MRKAwareDiscoveryAwsKmsMasterKeyProvider
     :param dict kwargs: Named parameters collected from CLI arguments as prepared
         in aws_encryption_sdk_cli.internal.master_key_parsing._parse_master_key_providers_from_args
     :rtype: aws_encryption_sdk.key_providers.kms.BaseKMSMasterKeyProvider
@@ -75,5 +81,5 @@ def aws_kms_master_key_provider(discovery=True, **kwargs):
             discovery_filter = DiscoveryFilter(account_ids=accounts, partition=partition)
             kwargs["discovery_filter"] = discovery_filter  # type: ignore
 
-        return DiscoveryAwsKmsMasterKeyProvider(**kwargs)
-    return StrictAwsKmsMasterKeyProvider(**kwargs)
+        return MRKAwareDiscoveryAwsKmsMasterKeyProvider(**kwargs)
+    return MRKAwareStrictAwsKmsMasterKeyProvider(**kwargs)

--- a/test/unit/test_key_providers.py
+++ b/test/unit/test_key_providers.py
@@ -38,14 +38,14 @@ def patch_botocore_session(mocker):
 
 @pytest.yield_fixture
 def patch_discovery_master_key_provider(mocker):
-    mocker.patch.object(key_providers, "DiscoveryAwsKmsMasterKeyProvider")
-    yield key_providers.DiscoveryAwsKmsMasterKeyProvider
+    mocker.patch.object(key_providers, "MRKAwareDiscoveryAwsKmsMasterKeyProvider")
+    yield key_providers.MRKAwareDiscoveryAwsKmsMasterKeyProvider
 
 
 @pytest.yield_fixture
 def patch_strict_master_key_provider(mocker):
-    mocker.patch.object(key_providers, "StrictAwsKmsMasterKeyProvider")
-    yield key_providers.StrictAwsKmsMasterKeyProvider
+    mocker.patch.object(key_providers, "MRKAwareStrictAwsKmsMasterKeyProvider")
+    yield key_providers.MRKAwareStrictAwsKmsMasterKeyProvider
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
CLI now supports Multi-Region Keys (MRKs).
Usage of MRKs is identical to the usage of non-MRK KMS Keys.
Though a KMS Key does not have to be a MRK Key for it to be used.

See https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview.html
for more details about AWS KMS multi-Region Keys.
See https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/configure.html#config-mrks
for more details about how the AWS Encryption SDK interoperates
with AWS KMS multi-Region keys.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
