### PR TITLE
chore: Fix deprecation warnings from pytest

### DIFF
--- a/test/unit/internal/test_arg_parsing.py
+++ b/test/unit/internal/test_arg_parsing.py
@@ -35,32 +35,32 @@ def patch_platform_win32_ver(mocker):
     return arg_parsing.platform.win32_ver
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_build_parser(mocker):
     mocker.patch.object(arg_parsing, "_build_parser")
     yield arg_parsing._build_parser
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_process_wrapping_key_provider_configs(mocker):
     mocker.patch.object(arg_parsing, "_process_wrapping_key_provider_configs")
     yield arg_parsing._process_wrapping_key_provider_configs
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_parse_and_collapse_config(mocker):
     mocker.patch.object(arg_parsing, "_parse_and_collapse_config")
     yield arg_parsing._parse_and_collapse_config
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_process_encryption_context(mocker):
     mocker.patch.object(arg_parsing, "_process_encryption_context")
     arg_parsing._process_encryption_context.return_value = sentinel.encryption_context, sentinel.required_keys
     yield arg_parsing._process_encryption_context
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_process_caching_config(mocker):
     mocker.patch.object(arg_parsing, "_process_caching_config")
     yield arg_parsing._process_caching_config

--- a/test/unit/internal/test_io_handling.py
+++ b/test/unit/internal/test_io_handling.py
@@ -31,13 +31,13 @@ pytestmark = [pytest.mark.unit, pytest.mark.local]
 DATA = b"aosidhjf9aiwhj3f98wiaj49c8a3hj49f8uwa0edifja9w843hj98"
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_makedirs(mocker):
     mocker.patch.object(io_handling.os, "makedirs")
     yield io_handling.os.makedirs
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_aws_encryption_sdk_stream(mocker):
     mocker.patch.object(io_handling.aws_encryption_sdk.EncryptionSDKClient, "stream")
     mock_stream = MagicMock()
@@ -65,19 +65,19 @@ def patch_for_process_single_operation(mocker, patch_single_io_write):
     mocker.patch.object(io_handling, "_ensure_dir_exists")
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_input(mocker):
     mocker.patch.object(io_handling.six.moves, "input")
     yield io_handling.six.moves.input
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_process_single_operation(mocker):
     mocker.patch.object(io_handling.IOHandler, "process_single_operation")
     yield io_handling.IOHandler.process_single_operation
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_should_write_file(mocker):
     mocker.patch.object(io_handling.IOHandler, "_should_write_file")
     io_handling.IOHandler._should_write_file.return_value = True

--- a/test/unit/internal/test_logging_utils.py
+++ b/test/unit/internal/test_logging_utils.py
@@ -21,25 +21,25 @@ from aws_encryption_sdk_cli.internal import logging_utils
 pytestmark = [pytest.mark.unit, pytest.mark.local]
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_logging_levels(mocker):
     mocker.patch.object(logging_utils, "_logging_levels")
     yield logging_utils._logging_levels
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_logging(mocker):
     mocker.patch.object(logging_utils, "logging")
     yield logging_utils.logging
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_blacklist_filter(mocker):
     mocker.patch.object(logging_utils, "_BlacklistFilter")
     yield logging_utils._BlacklistFilter
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_kms_key_redacting_formatter(mocker):
     mocker.patch.object(logging_utils, "_KMSKeyRedactingFormatter")
     yield logging_utils._KMSKeyRedactingFormatter

--- a/test/unit/internal/test_master_key_parsing.py
+++ b/test/unit/internal/test_master_key_parsing.py
@@ -26,39 +26,39 @@ from aws_encryption_sdk_cli.key_providers import aws_kms_master_key_provider
 pytestmark = [pytest.mark.unit, pytest.mark.local]
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_load_master_key_provider(mocker):
     mocker.patch.object(master_key_parsing, "_load_master_key_provider")
     yield master_key_parsing._load_master_key_provider
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_build_master_key_provider(mocker):
     mocker.patch.object(master_key_parsing, "_build_master_key_provider")
     master_key_parsing._build_master_key_provider.side_effect = (sentinel.key_provider_1, sentinel.key_provider_2)
     yield master_key_parsing._build_master_key_provider
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_assemble_master_key_providers(mocker):
     mocker.patch.object(master_key_parsing, "_assemble_master_key_providers")
     master_key_parsing._assemble_master_key_providers.return_value = sentinel.assembled_key_providers
     yield master_key_parsing._assemble_master_key_providers
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_parse_master_key_providers(mocker):
     mocker.patch.object(master_key_parsing, "_parse_master_key_providers_from_args")
     yield master_key_parsing._parse_master_key_providers_from_args
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_aws_encryption_sdk(mocker):
     mocker.patch.object(master_key_parsing, "aws_encryption_sdk")
     yield master_key_parsing.aws_encryption_sdk
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_iter_entry_points(mocker):
     mocker.patch.object(master_key_parsing.pkg_resources, "iter_entry_points")
     yield master_key_parsing.pkg_resources.iter_entry_points
@@ -76,7 +76,7 @@ def logger_stream():
     return output_stream
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def entry_points_cleaner():
     master_key_parsing._ENTRY_POINTS = defaultdict(dict)
     yield

--- a/test/unit/test_key_providers.py
+++ b/test/unit/test_key_providers.py
@@ -23,26 +23,26 @@ from aws_encryption_sdk_cli.internal.identifiers import USER_AGENT_SUFFIX
 pytestmark = [pytest.mark.unit, pytest.mark.local]
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_deepcopy(mocker):
     mocker.patch.object(key_providers.copy, "deepcopy")
     yield key_providers.copy.deepcopy
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_botocore_session(mocker):
     mocker.patch.object(key_providers.botocore.session, "Session")
     key_providers.botocore.session.Session.return_value = sentinel.botocore_session
     yield key_providers.botocore.session.Session
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_discovery_master_key_provider(mocker):
     mocker.patch.object(key_providers, "MRKAwareDiscoveryAwsKmsMasterKeyProvider")
     yield key_providers.MRKAwareDiscoveryAwsKmsMasterKeyProvider
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patch_strict_master_key_provider(mocker):
     mocker.patch.object(key_providers, "MRKAwareStrictAwsKmsMasterKeyProvider")
     yield key_providers.MRKAwareStrictAwsKmsMasterKeyProvider


### PR DESCRIPTION
*Description of changes:*

Similar to https://github.com/aws/aws-encryption-sdk-python/pull/351

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
