### PR TITLE
chore: fix broken static analysis (#242)

### DIFF
--- a/.github/workflows/ci_static-analysis.yaml
+++ b/.github/workflows/ci_static-analysis.yaml
@@ -29,7 +29,7 @@ jobs:
           - isort-check
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v2
         with:
           python-version: 3.x
       - run: |

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -38,7 +38,7 @@ jobs:
 #          - integ
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
           architecture: ${{ matrix.platform.architecture }}

--- a/codebuild/python_38.yml
+++ b/codebuild/python_38.yml
@@ -12,5 +12,7 @@ phases:
       python: latest
   build:
     commands:
-      - pip install tox
+      - pyenv install 3.8.12
+      - pyenv local 3.8.12
+      - pip install tox tox-pyenv
       - tox

--- a/src/pylintrc
+++ b/src/pylintrc
@@ -9,6 +9,10 @@ disable =
     useless-object-inheritance,
     raise-missing-from,
     super-with-arguments,
+    redundant-u-string-prefix, # This major version must support py2
+    consider-using-f-string, # This major version must support py2
+    no-member,  # breaks with attrs
+    unspecified-encoding, # our open() calls use binary, which does not support encoding
 
 [BASIC]
 # Allow function names up to 50 characters

--- a/test/pylintrc
+++ b/test/pylintrc
@@ -14,7 +14,21 @@
 # W0212 : protected-access (raised when calling _ methods)
 # W0621 : redefined-outer-name (raised when using pytest-mock)
 # W0613 : unused-argument (raised when patches are needed but not called)
-disable = C0103, C0111, C0330, C0412, E1101, R0205, R0801, R0903, R0914, W0212, W0621, W0613
+disable = 
+    C0103,
+    C0111,
+    C0330,
+    C0412,
+    E1101,
+    R0205,
+    R0801,
+    R0903,
+    R0914,
+    W0212,
+    W0621,
+    W0613,
+    consider-using-f-string, # This major version must support py2
+
 
 [VARIABLES]
 additional-builtins = raw_input

--- a/test/unit/internal/test_metadata.py
+++ b/test/unit/internal/test_metadata.py
@@ -31,7 +31,7 @@ GOOD_INIT_KWARGS = dict(suppress_output=False)
 @pytest.mark.parametrize(
     "init_kwargs, call_kwargs",
     (
-        (dict(suppress_output=True), dict()),
+        (dict(suppress_output=True), {}),
         (dict(suppress_output=False), dict(output_file="-")),
         (dict(suppress_output=False), dict(output_file="asdf")),
     ),
@@ -52,7 +52,7 @@ def test_attrs_fail(init_kwargs_patch, error_type):
 
 @pytest.mark.parametrize(
     "init_kwargs, call_kwargs, error_type, error_message",
-    ((dict(suppress_output=False), dict(), TypeError, r"output_file cannot be None when suppress_output is False"),),
+    ((dict(suppress_output=False), {}, TypeError, r"output_file cannot be None when suppress_output is False"),),
 )
 def test_custom_fail(init_kwargs, call_kwargs, error_type, error_message):
     with pytest.raises(error_type) as excinfo:

--- a/tox.ini
+++ b/tox.ini
@@ -78,9 +78,10 @@ basepython = python3
 deps =
     # mypy outputs coverage data in a coverage 4.x format
     coverage~=4.0
-    mypy
+    mypy==0.800
     mypy_extensions
     typing>=3.6.2
+    typed-ast
 
 [testenv:mypy-py3]
 basepython = {[testenv:mypy-common]basepython}


### PR DESCRIPTION
*Description of changes:*
Same as https://github.com/aws/aws-encryption-sdk-cli/pull/242, but on the 2.x branch.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
