### PR TITLE
ci(tox park): unpin python3 version

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -275,7 +275,7 @@ commands =
 
 # Release tooling
 [testenv:park]
-basepython = python3.8
+basepython = python3
 skip_install = true
 deps =
     pypi-parker


### PR DESCRIPTION
*Issue #, if available:* ci(tox park): unpin python3 version

*Description of changes:*

I have audited the three tox files I could find for any basepython that is not Python3. I only found park.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
