### PR TITLE
chore: fix generated docs

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -61,7 +61,7 @@ exclude_trees = ["_build"]
 pygments_style = "sphinx"
 
 autoclass_content = "both"
-autodoc_default_flags = ["show-inheritance", "members"]
+autodoc_default_options = {"show-inheritance": True, "members": True}
 autodoc_member_order = "bysource"
 
 html_theme = "sphinx_rtd_theme"


### PR DESCRIPTION
*Description of changes:*
Turns out when we moved to a newer version of sphinx (https://github.com/aws/aws-encryption-sdk-cli/pull/245) it changed how we need to specify config options.

See also: https://github.com/aws/aws-encryption-sdk-python/pull/383 and https://github.com/aws/aws-dynamodb-encryption-python/pull/191

*Testing:*
`tox -e serve-docs` shows me the full API docs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


