### PR TITLE
Pin tox park to python3 instead of python3.8

### DIFF
--- a/codebuild/release/prod-release.yml
+++ b/codebuild/release/prod-release.yml
@@ -17,7 +17,7 @@ phases:
   pre_build:
     commands:
       - git checkout $COMMIT_ID
-      - FOUND_VERSION=$(sed -n 's/__version__ = "\(.*\)"/\1/p' src/aws_encryption_sdk_cli/internal/identifiers.py)
+      - FOUND_VERSION=$(sed -n 's/__version__ = "\(.*\)".*/\1/p' src/aws_encryption_sdk_cli/internal/identifiers.py)
       - |
         if expr ${FOUND_VERSION} != ${VERSION}; then
           echo "identifiers.py version (${FOUND_VERSION}) does not match expected version (${VERSION}), stopping"

--- a/codebuild/release/test-release.yml
+++ b/codebuild/release/test-release.yml
@@ -17,7 +17,7 @@ phases:
   pre_build:
     commands:
       - git checkout $COMMIT_ID
-      - FOUND_VERSION=$(sed -n 's/__version__ = "\(.*\)"/\1/p' src/aws_encryption_sdk_cli/internal/identifiers.py)
+      - FOUND_VERSION=$(sed -n 's/__version__ = "\(.*\)".*/\1/p' src/aws_encryption_sdk_cli/internal/identifiers.py)
       - |
         if expr ${FOUND_VERSION} != ${VERSION}; then
           echo "identifiers.py version (${FOUND_VERSION}) does not match expected version (${VERSION}), stopping"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 base64io>=1.0.1
 aws-encryption-sdk~=1.10
 setuptools
-attrs>=17.1.0
+attrs>=17.1.0,<22.1.0

--- a/tox.ini
+++ b/tox.ini
@@ -272,7 +272,7 @@ commands =
 
 # Release tooling
 [testenv:park]
-basepython = python3.8
+basepython = python3
 skip_install = true
 deps =
     pypi-parker


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The `tox park` environment was pinned to 3.8 instead of 3. This was causing builds to fail since `latest` in CodeBuild is now 3.9

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
