### PR TITLE
fix: CodeBuild release script errors

### DIFF
--- a/codebuild/release/prod-release.yml
+++ b/codebuild/release/prod-release.yml
@@ -17,7 +17,7 @@ phases:
   pre_build:
     commands:
       - git checkout $COMMIT_ID
-      - FOUND_VERSION=$(sed -n 's/__version__ = "\(.*\)"/\1/p' src/aws_encryption_sdk_cli/internal/identifiers.py)
+      - FOUND_VERSION=$(sed -n 's/__version__ = "\(.*\)".*/\1/p' src/aws_encryption_sdk_cli/internal/identifiers.py)
       - |
         if expr ${FOUND_VERSION} != ${VERSION}; then
           echo "identifiers.py version (${FOUND_VERSION}) does not match expected version (${VERSION}), stopping"

--- a/codebuild/release/test-release.yml
+++ b/codebuild/release/test-release.yml
@@ -17,7 +17,7 @@ phases:
   pre_build:
     commands:
       - git checkout $COMMIT_ID
-      - FOUND_VERSION=$(sed -n 's/__version__ = "\(.*\)"/\1/p' src/aws_encryption_sdk_cli/internal/identifiers.py)
+      - FOUND_VERSION=$(sed -n 's/__version__ = "\(.*\)".*/\1/p' src/aws_encryption_sdk_cli/internal/identifiers.py)
       - |
         if expr ${FOUND_VERSION} != ${VERSION}; then
           echo "identifiers.py version (${FOUND_VERSION}) does not match expected version (${VERSION}), stopping"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 base64io>=1.0.1
 aws-encryption-sdk~=2.5
 setuptools
-attrs>=17.1.0
+attrs>=17.1.0,<22.1.0

--- a/tox.ini
+++ b/tox.ini
@@ -272,7 +272,7 @@ commands =
 
 # Release tooling
 [testenv:park]
-basepython = python3.8
+basepython = python3
 skip_install = true
 deps =
     pypi-parker


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* fix: Pin tox park to python3 instead of python3.8 (#304)
* fix: FOUND_VERSION regex working with mypy type annotation in comment
* fix: Add upper bound to attrs version: Starting with 22.1.0, attrs drops support for Python 2

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
