### PR TITLE
feat: Mark ESDK-CLI-1.x as EOS

### DIFF
--- a/src/aws_encryption_sdk_cli/__init__.py
+++ b/src/aws_encryption_sdk_cli/__init__.py
@@ -22,7 +22,6 @@ import aws_encryption_sdk
 from aws_encryption_sdk.materials_managers import CommitmentPolicy
 from aws_encryption_sdk.materials_managers.base import CryptoMaterialsManager  # noqa pylint: disable=unused-import
 
-
 from aws_encryption_sdk_cli.compatability import _warn_deprecated_python, _warn_end_of_support_cli
 from aws_encryption_sdk_cli.exceptions import AWSEncryptionSDKCLIError, BadUserArgumentError
 from aws_encryption_sdk_cli.internal.arg_parsing import CommitmentPolicyArgs, parse_args
@@ -268,7 +267,6 @@ def cli(raw_args=None):
         args = parse_args(raw_args)
 
         setup_logger(args.verbosity, args.quiet)
-
 
         _LOGGER.debug("Encryption mode: %s", args.action)
         _LOGGER.debug("Encryption source: %s", args.input)

--- a/src/aws_encryption_sdk_cli/__init__.py
+++ b/src/aws_encryption_sdk_cli/__init__.py
@@ -22,6 +22,8 @@ import aws_encryption_sdk
 from aws_encryption_sdk.materials_managers import CommitmentPolicy
 from aws_encryption_sdk.materials_managers.base import CryptoMaterialsManager  # noqa pylint: disable=unused-import
 
+
+from aws_encryption_sdk_cli.compatability import _warn_deprecated_python, _warn_end_of_support_cli
 from aws_encryption_sdk_cli.exceptions import AWSEncryptionSDKCLIError, BadUserArgumentError
 from aws_encryption_sdk_cli.internal.arg_parsing import CommitmentPolicyArgs, parse_args
 from aws_encryption_sdk_cli.internal.identifiers import __version__  # noqa
@@ -267,11 +269,15 @@ def cli(raw_args=None):
 
         setup_logger(args.verbosity, args.quiet)
 
+
         _LOGGER.debug("Encryption mode: %s", args.action)
         _LOGGER.debug("Encryption source: %s", args.input)
         _LOGGER.debug("Encryption destination: %s", args.output)
         _LOGGER.debug("Master key provider configuration: %s", args.master_keys)
         _LOGGER.debug("Suffix requested: %s", args.suffix)
+
+        _warn_deprecated_python()
+        _warn_end_of_support_cli()
 
         if args.wrapping_keys is not None:
             crypto_materials_manager = build_crypto_materials_manager_from_args(

--- a/src/aws_encryption_sdk_cli/compatability.py
+++ b/src/aws_encryption_sdk_cli/compatability.py
@@ -1,0 +1,50 @@
+# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+"""Contains logic for checking ESDK and Python Version"""
+import sys
+import warnings
+
+DEPRECATION_DATE_MAP = {"1.x": "2022-07-08", "2.x": "2022-07-13", "3.x": "2022-07-13"}
+
+
+def _warn_deprecated_python():
+    """Template for deprecation of Python warning."""
+    deprecated_versions = {
+        (2, 7): {"date": DEPRECATION_DATE_MAP["3.x"]},
+        (3, 4): {"date": DEPRECATION_DATE_MAP["3.x"]},
+        (3, 5): {"date": "2021-11-10"},
+    }
+    py_version = (sys.version_info.major, sys.version_info.minor)
+    minimum_version = (3, 6)
+
+    if py_version in deprecated_versions:
+        params = deprecated_versions[py_version]
+        warning = (
+            "aws-encryption-sdk will no longer support Python {}.{} "
+            "starting {}. To continue receiving service updates, "
+            "bug fixes, and security updates please upgrade to Python {}.{} or "
+            "later. For more information, see SUPPORT_POLICY.rst: "
+            "https://github.com/aws/aws-encryption-sdk-cli/blob/master/SUPPORT_POLICY.rst"
+        ).format(py_version[0], py_version[1], minimum_version[0], minimum_version[1], params["date"])
+        warnings.warn(warning, DeprecationWarning)
+
+
+def _warn_end_of_support_cli():
+    """Template for warning of end of support usage"""
+    warning = (
+        "This version of the aws-encryption-sdk-cli is no longer supported. "
+        "To continue receiving new features, bug fixes, and security upates, "
+        "please upgrade to the latest version. For more information, see SUPPORT_POLICY.rst: "
+        "https://github.com/aws/aws-encryption-sdk-cli/blob/master/SUPPORT_POLICY.rst"
+    )
+    warnings.warn(warning, DeprecationWarning)


### PR DESCRIPTION
*Issue #, if available:* Mark the ESDK-CLI-1.x as End of Support

*Description of changes:*
- Issues a log warning that this version is no longer supported.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
