### PR TITLE
feat: Mark 1.x, 2.x, & 3.x as EOS

### DIFF
--- a/SUPPORT_POLICY.rst
+++ b/SUPPORT_POLICY.rst
@@ -22,20 +22,20 @@ This table describes the current support status of each major version of the AWS
       - Next status
       - Next status date
     * - 1.x
-      - Maintenance
       - End of Support
-      - 2022-07-08
-    * - 2.x
-      - Maintenance
-      - End of Support
-      - 2022-07-13
-    * - 3.x
-      - General Availability
-      - Maintenance
-      - 2021-07-13
-    * - 4.x
       - 
-      - General Availability 
-      - 2021-07-13
+      - 
+    * - 2.x
+      - End of Support
+      - 
+      - 
+    * - 3.x
+      - End of Support
+      - 
+      - 
+    * - 4.x
+      - General Availability
+      - 
+      - 
 
 .. _AWS SDKs and Tools Maintenance Policy: https://docs.aws.amazon.com/sdkref/latest/guide/maint-policy.html#version-life-cycle

--- a/src/aws_encryption_sdk_cli/__init__.py
+++ b/src/aws_encryption_sdk_cli/__init__.py
@@ -24,6 +24,7 @@ import aws_encryption_sdk
 from aws_encryption_sdk.materials_managers import CommitmentPolicy
 from aws_encryption_sdk.materials_managers.base import CryptoMaterialsManager  # noqa pylint: disable=unused-import
 
+from aws_encryption_sdk_cli.compatability import _warn_end_of_support_cli
 from aws_encryption_sdk_cli.exceptions import AWSEncryptionSDKCLIError, BadUserArgumentError
 from aws_encryption_sdk_cli.internal.arg_parsing import CommitmentPolicyArgs, parse_args
 from aws_encryption_sdk_cli.internal.identifiers import __version__  # noqa
@@ -279,6 +280,7 @@ def cli(raw_args=None):
 
     :returns: Execution return value intended for ``sys.exit()``
     """
+     _warn_end_of_support_cli()
     try:
         args = parse_args(raw_args)
 

--- a/src/aws_encryption_sdk_cli/__init__.py
+++ b/src/aws_encryption_sdk_cli/__init__.py
@@ -280,7 +280,7 @@ def cli(raw_args=None):
 
     :returns: Execution return value intended for ``sys.exit()``
     """
-     _warn_end_of_support_cli()
+    _warn_end_of_support_cli()
     try:
         args = parse_args(raw_args)
 

--- a/src/aws_encryption_sdk_cli/compatability.py
+++ b/src/aws_encryption_sdk_cli/compatability.py
@@ -1,0 +1,25 @@
+# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+"""Contains logic for checking ESDK and Python Version"""
+import warnings
+
+
+def _warn_end_of_support_cli():
+    """Template for warning of end of support usage"""
+    warning = (
+        "This version of the aws-encryption-sdk-cli is no longer supported. "
+        "To continue receiving new features, bug fixes, and security upates, "
+        "please upgrade to the latest version. For more information, see SUPPORT_POLICY.rst: "
+        "https://github.com/aws/aws-encryption-sdk-cli/blob/master/SUPPORT_POLICY.rst"
+    )
+    warnings.warn(warning, DeprecationWarning)


### PR DESCRIPTION
*Issue #, if available:* Mark 1.x, 2.x, & 3.x as EOS

*Description of changes:*
- Issues a log warning that this version is no longer supported.

Updated the SUPPORT_POLICY.rst to:
- declare 1.x, 2.x, & 3.x in End of Support
- declare 4.x in GA (should have been done a long time ago...)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
