### PR TITLE
ci(mypy-py3): fix mypy-py3 static check

### DIFF
--- a/dev_requirements/coverage-requirements.txt
+++ b/dev_requirements/coverage-requirements.txt
@@ -1,4 +1,6 @@
 coverage==4.5.4
-mypy==0.812
+mypy==0.971
 mypy-extensions==0.4.3
 typing==3.7.4.3
+types-setuptools==63.2.2
+types-six==1.16.18

--- a/dev_requirements/linter-requirements.txt
+++ b/dev_requirements/linter-requirements.txt
@@ -6,7 +6,6 @@ flake8-docstrings==1.6.0
 flake8-print==4.0.0
 isort==5.10.1
 mock==4.0.3
-mypy==0.812
 pyflakes==2.4.0
 pylint==2.12.2
 pytest==7.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -87,6 +87,7 @@ basepython = {[testenv:mypy-common]basepython}
 deps = -rdev_requirements/coverage-requirements.txt
 commands =
     python -m mypy \
+        --show-error-codes \
         --linecoverage-report build \
         src/aws_encryption_sdk_cli/ \
         {posargs}


### PR DESCRIPTION
*Issue #, if available:* Fixes https://github.com/aws/aws-encryption-sdk-cli/actions/runs/2778718751

*Description of changes:*
Fix failing static analysis check by:
1. Upgrading mypy, which now recognizes that `attr` annotated classes are sub-classes of `AttrsInstance`
2. Adding `types-setuptools` and `types-six` to `coverage-requirements.txt`,
  which addresses issues raised by the updated `mypy`.

Additional changes to facilitate better static checking:
- Remove `mypy` from `linter-requirements` as it is only invoked when `coverage-requirements` is also loaded. This consolidates `mypy`'s pin to one file.
- Use `mypy`'s `--show-error-codes`, which will report what the typing error violated is.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
