### PR TITLE
chore: 1.x End-of-Support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,19 @@
 Changelog
 *********
 
+1.9.2 -- 2022-08-30
+===================
+
+Deprecation Announcement
+------------------------
+The AWS Encryption SDK CLI Major Version 1 is End of Support.
+It will no longer receive security updates or bug fixes.
+Consider updating to the latest version of the AWS Encryption SDK CLI.
+
+Operational
+-----------
+* Pin AWS Encryption SDK for Python dependency to at least 1.10.1
+
 1.9.1 -- 2022-07-21
 ===================
 

--- a/SUPPORT_POLICY.rst
+++ b/SUPPORT_POLICY.rst
@@ -1,0 +1,41 @@
+Overview
+========
+This page describes the support policy for the AWS Encryption SDK CLI. We regularly provide the AWS Encryption SDK CLI with updates that may contain support for new or updated APIs, new features, enhancements, bug fixes, security patches, or documentation updates. Updates may also address changes with dependencies, language runtimes, and operating systems.
+
+We recommend users to stay up-to-date with Encryption SDK CLI releases to keep up with the latest features, security updates, and underlying dependencies. Continued use of an unsupported SDK version is not recommended and is done at the user’s discretion.
+
+
+Major Version Lifecycle
+========================
+The AWS Encryption SDK follows the same major version lifecycle as the AWS SDK. For details on this lifecycle, see  `AWS SDKs and Tools Maintenance Policy`_.
+
+Version Support Matrix
+======================
+This table describes the current support status of each major version of the AWS Encryption SDK CLI. It also shows the next status each major version will transition to, and the date at which that transition will happen.
+
+.. list-table::
+    :widths: 30 50 50 50
+    :header-rows: 1
+
+    * - Major version
+      - Current status
+      - Next status
+      - Next status date
+    * - 1.x
+      - End of Support
+      - 
+      - 
+    * - 2.x
+      - End of Support
+      - 
+      - 
+    * - 3.x
+      - End of Support
+      - 
+      - 
+    * - 4.x
+      - General Availability 
+      - 
+      -
+
+.. _AWS SDKs and Tools Maintenance Policy: https://docs.aws.amazon.com/sdkref/latest/guide/maint-policy.html#version-life-cycle

--- a/api_compatibility_tests/tox.ini
+++ b/api_compatibility_tests/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py38-awses_cli_{1.7.0,1.8.0,1.9.0,1.9.1,2.0.0,2.1.0,2.2.0}
+    py38-awses_cli_{1.7.0,1.8.0,1.9.0,1.9.1,1.9.2,2.0.0,2.1.0,2.2.0}
 
 [testenv:base-command]
 commands = pytest --basetemp={envtmpdir} -l test/ {posargs}
@@ -24,6 +24,7 @@ deps =
     awses_cli_1.8.0: -rcompatibility-requirements/1.8.0
     awses_cli_1.9.0: -rcompatibility-requirements/1.9.0
     awses_cli_1.9.1: -rcompatibility-requirements/1.9.1
+    awses_cli_1.9.2: -rcompatibility-requirements/1.9.2
     awses_cli_2.0.0: -rcompatibility-requirements/2.0.0
     awses_cli_2.1.0: -rcompatibility-requirements/2.1.0
     awses_cli_2.2.0: -rcompatibility-requirements/2.2.0

--- a/codebuild/release/prod-release.yml
+++ b/codebuild/release/prod-release.yml
@@ -4,8 +4,8 @@ env:
   variables:
     BRANCH: "master"
   secrets-manager:
-    TWINE_USERNAME: PyPiAdmin:username 
-    TWINE_PASSWORD: PyPiAdmin:password
+    TWINE_USERNAME: PyPiAPIToken:username 
+    TWINE_PASSWORD: PyPiAPIToken:password
 
 phases:
   install:

--- a/codebuild/release/test-release.yml
+++ b/codebuild/release/test-release.yml
@@ -4,8 +4,8 @@ env:
   variables:
     BRANCH: "master"
   secrets-manager:
-    TWINE_USERNAME: TestPyPiCryptoTools:username 
-    TWINE_PASSWORD: TestPyPiCryptoTools:password
+    TWINE_USERNAME: TestPyPiAPIToken:username 
+    TWINE_PASSWORD: TestPyPiAPIToken:password
 
 phases:
   install:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 base64io>=1.0.1
-aws-encryption-sdk~=1.10
+aws-encryption-sdk~=1.10, >=1.10.1
 setuptools
 attrs>=17.1.0,<22.1.0

--- a/src/aws_encryption_sdk_cli/internal/identifiers.py
+++ b/src/aws_encryption_sdk_cli/internal/identifiers.py
@@ -31,7 +31,7 @@ __all__ = (
     "DEFAULT_MASTER_KEY_PROVIDER",
     "OperationResult",
 )
-__version__ = "1.9.1"  # type: str
+__version__ = "1.9.2"  # type: str
 
 #: Suffix added to output files if specific output filename is not specified.
 OUTPUT_SUFFIX = {


### PR DESCRIPTION
*Issue #, if available:* Mark 1.x End-of-Support

*Description of changes:*
- Update Changelog for release 1.9.2
- bump version for 1.9.2
- Pin AWS Encryption SDK for Python to at least version 1.10.1
- Add Support Policy

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
