### PR TITLE
fix(tox): docs needs install but build must skip_install

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -283,11 +283,9 @@ commands = python setup.py park
 basepython = python3
 skip_install = true
 deps =
-    {[testenv:docs]deps}
     wheel
     setuptools
 commands =
-    {[testenv:docs]commands}
     python setup.py sdist bdist_wheel
 
 [testenv:release-base]


### PR DESCRIPTION
*Issue #, if available:* Release 2.2.2

*Description of changes:* 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
