### PR TITLE
chore: Drop py36 from changelog

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,19 @@
 Changelog
 *********
 
+4.2.0 -- 2023-01-19
+===================
+
+Deprecation
+-----------
+The AWS Encryption SDK CLI no longer supports Python 3.6
+as of major version 4.2.x; only Python 3.7+ is supported.
+
+Maintenance
+-----------
+* Warn on Deprecated Python 3.6 usage
+
+
 4.1.0 -- 2021-10-11
 ===================
 

--- a/src/aws_encryption_sdk_cli/compatability.py
+++ b/src/aws_encryption_sdk_cli/compatability.py
@@ -23,9 +23,10 @@ def _warn_deprecated_python():
         (2, 7): {"date": DEPRECATION_DATE_MAP["3.x"]},
         (3, 4): {"date": DEPRECATION_DATE_MAP["3.x"]},
         (3, 5): {"date": "2021-11-10"},
+        (3, 6): {"date": "2023-01-19"},
     }
     py_version = (sys.version_info.major, sys.version_info.minor)
-    minimum_version = (3, 6)
+    minimum_version = (3, 7)
 
     if py_version in deprecated_versions:
         params = deprecated_versions[py_version]
@@ -35,5 +36,5 @@ def _warn_deprecated_python():
             "bug fixes, and security updates please upgrade to Python {}.{} or "
             "later. For more information, see SUPPORT_POLICY.rst: "
             "https://github.com/aws/aws-encryption-sdk-cli/blob/master/SUPPORT_POLICY.rst"
-        ).format(py_version[0], py_version[1], minimum_version[0], minimum_version[1], params["date"])
+        ).format(py_version[0], py_version[1], params["date"], minimum_version[0], minimum_version[1])
         warnings.warn(warning, DeprecationWarning)

--- a/src/aws_encryption_sdk_cli/internal/identifiers.py
+++ b/src/aws_encryption_sdk_cli/internal/identifiers.py
@@ -31,7 +31,7 @@ __all__ = (
     "DEFAULT_MASTER_KEY_PROVIDER",
     "OperationResult",
 )
-__version__ = "4.1.0"  # type: str
+__version__ = "4.2.0"  # type: str
 
 #: Suffix added to output files if specific output filename is not specified.
 OUTPUT_SUFFIX = {

--- a/test/unit/test_compatability.py
+++ b/test/unit/test_compatability.py
@@ -28,7 +28,7 @@ class TestWarnDeprecatedPython:
         """Asserts no warning for safe Python version."""
         with mock.patch.object(sys, "version_info") as v_info:
             v_info.major = 3
-            v_info.minor = 6
+            v_info.minor = 7
             with pytest.warns(None) as record:
                 _warn_deprecated_python()
             assert len(record) == 0


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Drop py36 from changelog
* Add warning for py36
* Fix warning format


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
