### PR TITLE
fix: Update README.rst to specify Python support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ Getting Started
 Required Prerequisites
 ======================
 
-* Python 3.6+
+* Python 3.7+
 * aws-encryption-sdk >= 3.1.0
 
 Installation


### PR DESCRIPTION
The readme incorrectly states that we support Python 3.6


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
